### PR TITLE
Tutorial - Doctrine PHPCR-ODM autoload route

### DIFF
--- a/tutorials/installing-configuring-doctrine-phpcr-odm.rst
+++ b/tutorials/installing-configuring-doctrine-phpcr-odm.rst
@@ -55,7 +55,7 @@ Register annotations
 Add file to annotation registry in ``app/autoload.php`` for the ODM annotations right after the last ``AnnotationRegistry::registerFile`` line::
 
     // ...
-    AnnotationRegistry::registerFile(__DIR__.'/../vendor/symfony-cmf/vendor/doctrine-phpcr-odm/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/DoctrineAnnotations.php');
+    AnnotationRegistry::registerFile(__DIR__.'/../vendor/doctrine/phpcr-odm/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/DoctrineAnnotations.php');
     // ...
     
 Initialize bundles


### PR DESCRIPTION
The route in the tutorial points to the wrong folder. This PR corrects that route to where actually is.
