### PR TITLE
symfony-cmf/liip-vie-bundle does not exist, replaced by liip/vie-bundle

### DIFF
--- a/tutorials/installing-configuring-inline-editing.rst
+++ b/tutorials/installing-configuring-inline-editing.rst
@@ -19,7 +19,7 @@ Add the following to your ``composer.json`` file::
 
     "require": {
         ...
-        "symfony-cmf/liip-vie-bundle": "1.0.*"
+        "liip/vie-bundle": "dev-master"
     },
     "scripts": {
         "post-install-cmd": [


### PR DESCRIPTION
seems that symfony-cmf/liip-vie-bundle does not exist anymore
