### PR TITLE
changed :doc: links to use relative paths instead of absolute ones

### DIFF
--- a/bundles/menu.rst
+++ b/bundles/menu.rst
@@ -119,5 +119,5 @@ Unless you change defaults and provide your own implementations, this bundle als
 
 * ``SymfonyRoutingExtraBundle`` for the router service ``symfony_cmf_routing_extra.dynamic_router``.
   Note that you need to explicitly enable the dynamic router as per default it is not loaded.
-  See the :doc:`documentation of the routing extra bundle</bundles/routing-extra>` for how to do this.
-* :doc:`/bundles/phpcr-odm` to load route documents from the content repository
+  See the :doc:`documentation of the routing extra bundle<routing-extra>` for how to do this.
+* :doc:`phpcr-odm` to load route documents from the content repository

--- a/bundles/phpcr-odm.rst
+++ b/bundles/phpcr-odm.rst
@@ -17,7 +17,7 @@ Doctrine PHPCR ODM to provide the ODM document manager in symfony.
 Setup
 -----
 
-See :doc:`/tutorials/installing-configuring-doctrine-phpcr-odm`
+See :doc:`../tutorials/installing-configuring-doctrine-phpcr-odm`
 
 
 Configuration

--- a/bundles/routing-extra.rst
+++ b/bundles/routing-extra.rst
@@ -2,7 +2,7 @@ RoutingExtraBundle
 ============================
 
 The `RoutingExtraBundle <https://github.com/symfony-cmf/RoutingExtraBundle#readme>`_
-integrates dynamic routing into Symfony using :doc:`/components/routing`.
+integrates dynamic routing into Symfony using :doc:`../components/routing`.
 
 The ``ChainRouter`` is meant to replace the default Symfony Router. All it does
 is collect a prioritized list of routers and try to match requests and generate

--- a/bundles/simple-cms.rst
+++ b/bundles/simple-cms.rst
@@ -136,4 +136,4 @@ frontend. The most simple form is the following twig block:
     {% endblock %}
 
 If you want to control more detailed what should be shown with RDFa, see
-chapter :doc:`/bundles/create`.
+chapter :doc:`create`.

--- a/bundles/tree-browser.rst
+++ b/bundles/tree-browser.rst
@@ -2,7 +2,7 @@ TreeBrowserBundle
 =================
 
 The `TreeBrowserBundle <https://github.com/symfony-cmf/TreeBrowserBundle#readme>`_
-provides integration with :doc:`/bundles/tree` to provide a tree navigation on top of a PHPCR repository.
+provides integration with :doc:`tree` to provide a tree navigation on top of a PHPCR repository.
 
 This bundle consists of two parts:
 

--- a/components/routing.rst
+++ b/components/routing.rst
@@ -5,7 +5,7 @@ The `Symfony2 CMF Routing component <https://github.com/symfony-cmf/Routing>`_
 library extends the Symfony2 core routing component. Even though it has Symfony
 in its name, it does not need the full Symfony2 framework and can be used in
 standalone projects. For integration with Symfony we  provide
-:doc:`/bundles/routing-extra`.
+:doc:`../bundles/routing-extra`.
 
 This component provides a ``ChainRouter`` that can chain several RouterInterface
 instances one after the other. It uses a list of routers, ordered by a priority

--- a/tutorials/creating-cms-using-cmf-and-sonata.rst
+++ b/tutorials/creating-cms-using-cmf-and-sonata.rst
@@ -14,7 +14,7 @@ Documentation TODO
 Preconditions
 -------------
 
-- :doc:`/tutorials/installing-configuring-cmf`
+- :doc:`installing-configuring-cmf`
 
 Installation
 ------------

--- a/tutorials/installing-configuring-cmf.rst
+++ b/tutorials/installing-configuring-cmf.rst
@@ -20,7 +20,7 @@ If you just want to get started with a minimal installation it is recommended to
 Preconditions
 -------------
 - `Installation of Symfony2 <http://symfony.com/doc/master/index.html>`_
-- :doc:`/tutorials/installing-configuring-doctrine-phpcr-odm`
+- :doc:`installing-configuring-doctrine-phpcr-odm`
 
 Installation
 ------------
@@ -100,7 +100,7 @@ following to your project configuration
                 enabled: true
 
 You might want to configure more on the dynamic router, i.e. to automatically choose controllers based on content.
-See :doc:`/bundles/routing-extra`
+See :doc:`../bundles/routing-extra`
 
 For a basic functionality for the BlockBundle (required)
 
@@ -114,4 +114,4 @@ For a basic functionality for the BlockBundle (required)
 
 For now this is the only configuration we need. Mastering the configuration of the different
 bundles will be handled in further tutorials. If you're looking for the configuration of a
-specific bundle take a look at the corresponding :doc:`bundles entry</index>`.
+specific bundle take a look at the corresponding :doc:`bundles entry<../index>`.

--- a/tutorials/installing-configuring-inline-editing.rst
+++ b/tutorials/installing-configuring-inline-editing.rst
@@ -85,4 +85,4 @@ The filename is the full class name including namespace with the backslashes ``\
 Reference
 ---------
 
-See :doc:`/bundles/create`
+See :doc:`../bundles/create`

--- a/tutorials/installing-configuring-simple-cms.rst
+++ b/tutorials/installing-configuring-simple-cms.rst
@@ -21,8 +21,8 @@ another application using the SimpleCmsBundle.
 
 Preconditions
 -------------
-- :doc:`/tutorials/installing-configuring-cmf` (TODO: make this tutorial more self-contained)
-- Or :doc:`/bundles/routing-extra` needs to be installed manually, optionally also :doc:`/bundles/menu` and :doc:`/bundles/block`
+- :doc:`installing-configuring-cmf` (TODO: make this tutorial more self-contained)
+- Or :doc:`../bundles/routing-extra` needs to be installed manually, optionally also :doc:`../bundles/menu` and :doc:`../bundles/block`
 
 Installation
 ------------
@@ -76,4 +76,4 @@ Next step is to configure the bundles.
                 templates_by_class:
                     Symfony\Cmf\Bundle\SimpleCmsBundle\Document\Page:  SymfonyCmfSimpleCmsBundle:Page:index.html.twig
 
-For the full reference, see :doc:`/bundles/simple-cms`.
+For the full reference, see :doc:`../bundles/simple-cms`.


### PR DESCRIPTION
Using relative links is required for the docs to display well on symfony.com
