### PR TITLE
Fixed RouteNotFoundException in admin dashboard

### DIFF
--- a/tutorials/creating-cms-using-cmf-and-sonata.rst
+++ b/tutorials/creating-cms-using-cmf-and-sonata.rst
@@ -142,6 +142,11 @@ Add route in to your routing configuration
             resource: '@SonataAdminBundle/Resources/config/routing/sonata_admin.xml'
             prefix: /admin
 
+        _sonata_admin:
+            resource: .
+            type: sonata_admin
+            prefix: /admin
+
         fos_js_routing:
             resource: "@FOSJsRoutingBundle/Resources/config/routing/routing.xml"
         


### PR DESCRIPTION
Comparing the routing file with cmf-sandbox routing file I realised that it was missing:

_sonata_admin:
    resource: .
    type: sonata_admin
    prefix: /admin

Adding the above config fixes this issue.
