### PR TITLE
ODM automapping missing

### DIFF
--- a/tutorials/installing-configuring-doctrine-phpcr-odm.rst
+++ b/tutorials/installing-configuring-doctrine-phpcr-odm.rst
@@ -166,6 +166,8 @@ Basic configuration for each content repository is shown below; add the appropri
                 workspace: default
                 username: admin
                 password: admin
+        odm:
+            auto_mapping: true
 
 **Jackalope with Doctrine DBAL**
 


### PR DESCRIPTION
Create and list actions from dashboard were throwing: 
The class 'Symfony\Cmf\Bundle\RoutingExtraBundle\Document\Route' was not found in the chain configured namespaces Doctrine\ODM\PHPCR\Document

Comparing with cmf-sandbox config file, I noticed the config in this tutorial was missing:

    odm:
        auto_mapping: true

Adding this to doctrine_phpcr config fixes the issue.

PS only added this to jackrabbit config as I havent tried DBAL yet.
