### PR TITLE
Should the priority for the dynamic_router be 200?

### DIFF
--- a/tutorials/installing-configuring-cmf.rst
+++ b/tutorials/installing-configuring-cmf.rst
@@ -118,7 +118,7 @@ not loaded, you will need to enable it as follows:
         symfony_cmf_routing_extra:
             chain:
                 routers_by_id:
-                    symfony_cmf_routing_extra.dynamic_router: 20
+                    symfony_cmf_routing_extra.dynamic_router: 200
                     router.default: 100
             dynamic:
                 enabled: true


### PR DESCRIPTION
Should the dynamic router priority be higher than default router?
