### PR TITLE
Fix a typo in a title's cookbook

### DIFF
--- a/cookbook/using-a-custom-route-repository.rst
+++ b/cookbook/using-a-custom-route-repository.rst
@@ -1,4 +1,4 @@
-Using a custom route repository with Dynmaic Router
+Using a custom route repository with Dynamic Router
 ===================================================
 
 The Dynamic Router allows you to customize the route Repository (i.e. the class 


### PR DESCRIPTION
Fix the word "Dynmaic" to "Dynamic" in the "Using a custom route repository" cookbook's title.
