### PR TITLE
Add block bundle configuration

### DIFF
--- a/bundles/block/introduction.rst
+++ b/bundles/block/introduction.rst
@@ -53,6 +53,20 @@ The configuration key for this bundle is ``symfony_cmf_block``:
             'document_manager_name' => 'default',
         ));
 
+The default settings of a block are defined in the block service. If you use a
+3rd party block you might want to alter these for your application. Use the
+``sonata_block`` key for this.
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config/config.yml
+        sonata_block:
+            blocks:
+                acme_main.block.rss:
+                    settings:
+                        maxItems: 3
 
 .. _bundle-block-document:
 
@@ -154,6 +168,8 @@ The method ``getDefaultSettings`` specifies the default settings for a block.
 Settings can be altered on multiple places afterwards, it cascades like this:
 
 * Default settings are stored in the block service;
+* If you use a 3rd party bundle you might want to change them in the bundle
+  configuration for your application see :ref:`configuration`;
 * Settings can be altered through template helpers (see example);
 * And settings can also be altered in a block document, the advantage is that
   settings are stored in PHPCR and allows to implement a frontend or backend UI

--- a/tutorials/using_blockbundle_and_contentbundle.rst
+++ b/tutorials/using_blockbundle_and_contentbundle.rst
@@ -498,10 +498,11 @@ This happens when a block is rendered, see the .. index:: BlockBundle for more d
 
     A block can also be configured using settings, this allows you to create
     more advanced blocks and reuse it. The default settings are configured in
-    the block service and can be altered in the twig helper and the block
-    document.  An example is an rss reader block, the url and title are stored
-    in the settings of the block document, the maximum amount of items to
-    display is specified when calling ``sonata_block_render``.
+    the block service and can be altered in the bundle configuration, the twig
+    helper and the block document.  An example is an rss reader block, the url
+    and title are stored in the settings of the block document, the maximum
+    amount of items to display is specified when calling
+    ``sonata_block_render``.
 
 .. _tutorial-block-embed:
 


### PR DESCRIPTION
This was first part of https://github.com/symfony-cmf/symfony-cmf-docs/pull/70 and is related to: 
- https://github.com/sonata-project/SonataBlockBundle/pull/43, in bundles/block.rst:
  - added an example in the configuration section
  - mentioned in the configuration cascading explanation of the subsection _default settings_ of the section _Block Service_
