### PR TITLE
Problem with the routes in SonataDoctrineAdminBundle tutorial

### DIFF
--- a/tutorials/creating-cms-using-cmf-and-sonata.rst
+++ b/tutorials/creating-cms-using-cmf-and-sonata.rst
@@ -147,6 +147,9 @@ Add route in to your routing configuration
             type: sonata_admin
             prefix: /admin
 
+        doctrine_phpcr_admin_bundle_odm_browser:
+            resource: "@SonataDoctrinePHPCRAdminBundle/Resources/config/routing/phpcrodmbrowser.xml"
+
         fos_js_routing:
             resource: "@FOSJsRoutingBundle/Resources/config/routing/routing.xml"
 


### PR DESCRIPTION
This fix is via lsmith help, although I am not sure if I labeled the route right or put it in the right place. 

This fixes an error in the "Creating CMS using CMF and Sonata" tutorial
where it requires the routes in SonataDoctrinePhpcrAdminBundle/blob/master/Resources/config/routing/phpcrodmbrowser.xml to be included. It seems to related to the TODO within the
phpcrodmbrowser.xml file stating: `TODO: route only exists for Symfony2.1 compat
https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/issues/86'
