### PR TITLE
System requirements

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -45,15 +45,8 @@ There are basically two main target audiences:
 Requirements
 ------------
 
-Symfony CMF is composed of several bundles running on top of `Symfony2`_. While
-calculating the system requirements, all the bundles used has to be taken into account.
-Here are the most notable:
-
-.. toctree::
-	:maxdepth: 1
-
-	`Symfony2_requirements`_
-	MySQL >= 5.1.5 (if using jackalope-doctrine-dbal with MySQL connection)
+* `Symfony2 requirements`_
+* MySQL >= 5.1.5 (if using ``jackalope-doctrine-dbal`` with MySQL connection)
 
 Getting started
 ---------------


### PR DESCRIPTION
I tried using the CMF on one of our testing servers with MySQL 5.0.51 and it failed:

```
SQLSTATE[42000]: Syntax error or access violation: 1305 FUNCTION cmf-app.EXTRACTVALUE does not exist 
```

It seems the function ExtractValue() used by jackalope-doctrine-dbal was added in MySQL 5.1.5.

Reference:
- http://dev.mysql.com/doc/refman/5.1/en/xml-functions.html

@dbu already added the requirement to the jackalope-doctrine-dbal repository:
- https://github.com/jackalope/jackalope-doctrine-dbal/commit/d884ee8ac706a297aa83c9247b61ff73ed122c3d
