### PR TITLE
Fixed doc standards and made corrections

### DIFF
--- a/bundles/block.rst
+++ b/bundles/block.rst
@@ -35,7 +35,7 @@ The configuration key for this bundle is ``symfony_cmf_block``
 
     .. code-block:: xml
 
-        <!-- app/config/config.xml !-->
+        <!-- app/config/config.xml -->
         <symfony-cmf-block:config document-manager-name="default"/>
 
     ..code-block:: php


### PR DESCRIPTION
- In addition to general text improvements and standards the document now also says that
  you can specify a block by an absolute path.
