### PR TITLE
[Getting Started] Fixed Symfony docs Standards and more

### DIFF
--- a/getting-started/content.rst
+++ b/getting-started/content.rst
@@ -12,7 +12,7 @@ can manipulate and that will later be presented to the page's users. The content
 structure greatly depends on the project's needs, and it will have a significant
 impact on future development and use of the platform.
 
-Symfony CMF SE comes with the ``ContentBundle``: a basic implementation of a
+Symfony CMF SE comes with the ContentBundle: a basic implementation of a
 content structure, including support for multiple languages and database storage
 of Routes.
 
@@ -28,9 +28,9 @@ a tree-like hierarchy. It also includes a Block reference (more on that later).
 The two implemented interfaces reveal two of the features included in this
 implementation:
 
-- ``RouteAwareInterface`` means that the content has associated Routes.
+* ``RouteAwareInterface`` means that the content has associated Routes.
 
-- ``PublishWorkflowInterface`` means that the content has publishing and
+* ``PublishWorkflowInterface`` means that the content has publishing and
    unpublishing dates, which will be handled by Symfony CMF's core to determine
    access.
 
@@ -54,32 +54,33 @@ It also specifies the translation strategy:
         */
 
 For information on the available translation strategies, refer to the Doctrine
-page regarding `Multilanguage support in PHPCR-ODM <http://docs.doctrine-project.org/projects/doctrine-phpcr-odm/en/latest/reference/multilang.html>`_
+page regarding `multilanguage support in PHPCR-ODM`_.
 
 
 Content Controller
 ------------------
 
-To handle both content types, a ``Controller`` is also included. Its inner
-workings are pretty straightforward: it accepts a content instance and optionally
+To handle both content types, a controller is also included. Its inner
+workings are pretty straightforward: It accepts a content instance and optionally
 a template to render it. If none is provided, it uses a pre-configured default.
 It also takes into account the document's publishing status and multi language.
-Both the content instance and the optional template are provided to the Controller
-by the ``DynamicRouter`` of the ``RoutingExtraBundle``. More information on this is
-available on the :ref:`Routing system getting started page <start-routing-linking-a-route-with-a-model-instance>`
+Both the content instance and the optional template are provided to the controller
+by the ``DynamicRouter`` of the RoutingExtraBundle. More information on this is
+available on the
+:ref:`Routing system getting started page <start-routing-linking-a-route-with-a-model-instance>`
 page.
 
 Admin Support
 -------------
 
 The last component needed to handle the included content types is an administration
-panel. Symfony CMF can optionally support `SonataDoctrinePHPCRAdminBundle <https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle>`_
+panel. Symfony CMF can optionally support `SonataDoctrinePHPCRAdminBundle`_
 , a back office generation tool. For more information about it, please refer
-to the bundle's `documentation section <https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/tree/master/Resources/doc>`_.
+to the bundle's `documentation section`_.
 
-In ``ContentBundle``, the required administration panels are already declared
+In ContentBundle, the required administration panels are already declared
 in the ``Admin`` folder and configured in ``Resources/config/admin.xml``,
-and will automatically be loaded if you install ``SonataDoctrinePHPCRAdminBundle``
+and will automatically be loaded if you install the SonataDoctrinePHPCRAdminBundle
 (refer to :doc:`../tutorials/creating-cms-using-cmf-and-sonata` for instructions
 on that).
 
@@ -97,3 +98,7 @@ CMS, it often will not provide all you need. The main idea behind it is to
 provide developers with a small and easy to understand starting point you can
 extend or use as inspiration to develop your own content types, Controllers and
 Admin panels.
+
+.. _`multilanguage support in PHPCR-ODM`: http://docs.doctrine-project.org/projects/doctrine-phpcr-odm/en/latest/reference/multilang.html
+.. _`SonataDoctrinePHPCRAdminBundle`: https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle
+.. _`documentation section`: https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/tree/master/Resources/doc

--- a/getting-started/installing-symfony-cmf.rst
+++ b/getting-started/installing-symfony-cmf.rst
@@ -12,16 +12,16 @@ custom application.
 If this is your first encounter with the Symfony CMF it would be a good idea to first take a
 look at:
 
-- `The Big Picture <http://slides.liip.ch/static/2012-01-17_symfony_cmf_big_picture.html#1>`_
-- The online sandbox demo at `cmf.liip.ch <http://cmf.liip.ch>`_
+- `The Big Picture`_
+- The online sandbox demo at `cmf.liip.ch`_
 
 .. note::
 
     For other Symfony CMF installation guides, please read:
 
-    - The cookbook entry on :doc:`../cookbook/installing-cmf-sandbox` for instructions on
+    * The cookbook entry on :doc:`../cookbook/installing-cmf-sandbox` for instructions on
       how to install a more complete demo instance of Symfony CMF.
-    - :doc:`../tutorials/installing-cmf-core` for step-by-step installation and
+    * :doc:`../tutorials/installing-cmf-core` for step-by-step installation and
       configuration details of just the core components into an existing Symfony
       application.
 
@@ -29,8 +29,8 @@ Preconditions
 -------------
 
 As Symfony CMF is based on Symfony2, you should make sure you meet the
-`Requirements for running Symfony2 <http://symfony.com/doc/current/reference/requirements.html>`_.
-Additionally, you need to have `SQLite <http://www.sqlite.org/>`_ PDO extension (pdo_sqlite)
+`Requirements for running Symfony2`_.
+Additionally, you need to have `SQLite`_ PDO extension (``pdo_sqlite``)
 installed, since it is used as the default storage medium.
 
 .. note::
@@ -42,15 +42,13 @@ installed, since it is used as the default storage medium.
     available mechanisms and how to install and configure them, refer to
     :doc:`../tutorials/installing-configuring-doctrine-phpcr-odm`
 
-`Git <http://git-scm.com/>`_ and `Curl <http://curl.haxx.se/>`_ are also
-needed to follow the installation steps listed below.
+`Git`_ and `Curl`_ are also needed to follow the installation steps listed below.
 
 
 Installation
 ------------
 
-The easiest way to install Symfony CMF is is using `Composer <http://getcomposer.org/>`_.
-Get it using
+The easiest way to install Symfony CMF is is using `Composer`_. Get it using
 
 .. code-block:: bash
 
@@ -71,9 +69,9 @@ and then get the Symfony CMF code with it (this may take a while)
 
 This will clone the standard edition and install all the dependencies and run some initial commands.
 These commands require write permissions to the ``app/cache`` and ``app/logs`` directory. In case
-the final commands end up giving permissions errors, please follow the `guidelines in the official
-documentation <http://symfony.com/doc/master/book/installation.html#configuration-and-setup>`_ for
-configuring the permissions and then run the ``composer.phar install`` command mentioned below.
+the final commands end up giving permissions errors, please follow the
+`guidelines in the symfony book`_ for configuring the permissions and then run the
+``composer.phar install`` command mentioned below.
 
 If you prefer you can also just clone the project:
 
@@ -127,15 +125,15 @@ Edition (SE) and how they work together to provide the default pages you
 can see when browsing the Symfony CMF SE installation.
 
 It assumes you have already installed Symfony CMF SE and have carefully
-read `the Symfony2 book <http://symfony.com/doc/current/book/>`_.
+read `the Symfony2 book`_.
 
 .. note::
 
     For other Symfony CMF installation guides, please read:
 
-    - The cookbook entry on :doc:`../cookbook/installing-cmf-sandbox` for instructions on how to
+    * The cookbook entry on :doc:`../cookbook/installing-cmf-sandbox` for instructions on how to
       install a more complete demo instance of Symfony CMF.
-    - :doc:`../tutorials/installing-cmf-core` for step-by-step installation and configuration
+    * :doc:`../tutorials/installing-cmf-core` for step-by-step installation and configuration
       details of just the core components into an existing Symfony application.
 
 AcmeMainBundle and SimpleCMSBundle
@@ -145,20 +143,20 @@ Symfony CMF SE comes with a default AcmeMainBundle to help you get started,
 in a similar way that Symfony2 has AcmeDemoBundle, providing you some
 demo pages visible on your browser. However, AcmeMainBundle doesn't include
 controllers or configuration files, like you probably would expect. It contains
-little more than a twig file and `Fixtures <http://symfony.com/doc/current/bundles/DoctrineFixturesBundle/index.html>`_
-data, that was loaded into your database during installation.
+little more than a twig file and `Fixtures`_ data, that was loaded into your
+database during installation.
 
 There are several bundles working together in order to turn the fixture data
 into a browsable website. The overall, simplified process is:
 
-- When a request is received, the Symfony CMF :doc:`routing`'s Dynamic Router is used to handle the
-  incoming request.
-- The Dynamic Router is able to match the requested URL with a specific ContentBundle's Content
-  stored in the database.
-- The retrieved content's information is used to determine which controller to pass it on to, and
-  which template to use.
-- As configured, the retrieved content is passed to ContentBundle's ContentController, which will
-  handle it and render AcmeMainBundle's layout.html.twig.
+* When a request is received, the :doc:`Symfony CMF Routing's Dynamic Router <routing>` is used
+  to handle the incoming request;
+* The Dynamic Router is able to match the requested URL with a specific ContentBundle's Content
+  stored in the database;
+* The retrieved content's information is used to determine which controller to pass it on to, and
+  which template to use;
+* As configured, the retrieved content is passed to ContentBundle's
+  ``ContentController``, which will handle it and render AcmeMainBundle's ``layout.html.twig``.
 
 Again, this is simplified view of a very simple CMS built on top of Symfony CMF.
 To fully understand all the possibilities of the CMF, a careful look into
@@ -192,3 +190,14 @@ create a file ````app/Resources/data/pages/test/foo.yml`` and then run the follo
 .. code-block:: bash
 
     $ php app/console doctrine:phpcr:migrator page --identifier=/cms/simple/test/foo
+
+.. _`The Big Picture`: http://slides.liip.ch/static/2012-01-17_symfony_cmf_big_picture.html#1
+.. _`cmf.liip.ch`: http://cmf.liip.ch
+.. _`Requirements for running Symfony2`: http://symfony.com/doc/current/reference/requirements.html
+.. _`SQLite`: http://www.sqlite.org/
+.. _`Git`: http://git-scm.com/
+.. _`Curl`: http://curl.haxx.se/
+.. _`Composer`: http://getcomposer.org/
+.. _`guidelines in the symfony book`: http://symfony.com/doc/master/book/installation.html#configuration-and-setup
+.. _`the Symfony2 book`: http://symfony.com/doc/current/book/
+.. _`Fixtures`: http://symfony.com/doc/current/bundles/DoctrineFixturesBundle/index.html

--- a/getting-started/menu.rst
+++ b/getting-started/menu.rst
@@ -17,27 +17,27 @@ multiple options, thus making them a complex problem themselves.
 Symfony CMF Menu System
 -----------------------
 
-Symfony CMF SE includes the ``MenuBundle``, a tool that allow you to dynamically
-define your menus. It extends `KnpMenuBundle <https://github.com/knplabs/KnpMenuBundle>`_,
-with a set of hierarchical, multi language menu elements, along with the tools
-to load and store them from/to a database. It also includes the administration
-panel definitions and related services needed for integration with
-`SonataDoctrinePhpcrAdminBundle <https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle>`_
+Symfony CMF SE includes the MenuBundle, a tool that allow you to dynamically
+define your menus. It extends the `KnpMenuBundle`_, with a set of
+hierarchical, multi language menu elements, along with the tools to load and
+store them from/to a database. It also includes the administration panel
+definitions and related services needed for integration with the
+`SonataDoctrinePhpcrAdminBundle`_.
 
 .. note::
 
-    The ``MenuBundle`` extends and greatly relies on `KnpMenuBundle <https://github.com/knplabs/KnpMenuBundle>`_,
-    so you should carefully read `KnpMenuBundle's documentation <https://github.com/KnpLabs/KnpMenuBundle/blob/master/Resources/doc/index.md>`_.
-    For the rest of this page we assume you have done so, and are familiar
-    with concepts like Menu Providers and Menu Factories.
+    The MenuBundle extends and greatly relies on the `KnpMenuBundle`_, so you
+    should carefully read `KnpMenuBundle's documentation`_. For the rest of
+    this page we assume you have done so and are familiar with concepts like
+    Menu Providers and Menu Factories.
 
 
 Usage
 ~~~~~
 
-``MenuBundle`` uses ``KnpMenuBundle``'s default renderers and helpers to
-print out menus. You can refer to the `respective documentation page <https://github.com/KnpLabs/KnpMenuBundle/blob/master/Resources/doc/index.md#rendering-menus>`_
-for more information on the subject, but a basic call would be:
+The MenuBundle uses KnpMenuBundle's default renderers and helpers to print out
+menus. You can refer to the `respective documentation page`_ for more
+information on the subject, but a basic call would be:
 
 .. configuration-block::
 
@@ -56,7 +56,7 @@ section.
 The Provider
 ~~~~~~~~~~~~
 
-The core of ``MenuBundle`` is ``PHPCRMenuProvider``, a ``MenuProviderInterface``
+The core of the MenuBundle is ``PHPCRMenuProvider``, a ``MenuProviderInterface``
 implementation that's responsible for dynamically loading menus from a PHPCR
 database. The default provider service is configured with a ``menu_basepath`` to
 know where in the PHPCR tree it will find menus. The menu ``name`` is given when
@@ -76,9 +76,15 @@ menu ``simple``, the menu root node must be stored at ``/cms/menu/simple``.
 
     .. code-block:: xml
 
-        <symfony-cmf-menu:config>
-            <symfony-cmf-menu:menu-basepath>/cms/menu</symfony-cmf-menu:menu-basepath>
-        </symfony-cmf-menu:config>
+        <?xml version="1.0" encoding="UTF-8" ?>
+
+        <container xmlns="http://cmf.symfony.com/schema/dic/menu"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+            <symfony-cmf-menu:config xmlns="http://cmf.symfony.com/schema/dic/menu">
+                <menu-basepath>/cms/menu</menu-basepath>
+            </symfony-cmf-menu:config>
+        </container>
 
     .. code-block:: php
 
@@ -87,7 +93,7 @@ menu ``simple``, the menu root node must be stored at ``/cms/menu/simple``.
         ));
 
 If you need multiple menu roots, you can create further PHPCRMenuProvider instances
-and register them with KnpMenu - see the CMF MenuBundle DependencyInjection code
+and register them with KnpMenu - see the CMF MenuBundle ``DependencyInjection`` code
 for the details.
 
 The menu element fetched using this process is used as the menu root node,
@@ -129,7 +135,7 @@ implement ``NodeInterface`` in order to be included in the generated menu.
 The Menu Nodes
 ~~~~~~~~~~~~~~
 
-Also included in ``MenuBundle`` come two menu node content types: ``MenuNode``
+Also included in the MenuBundle come two menu node content types: ``MenuNode``
 and ``MultilangMenuNode``. If you have read the documentation page regarding
 :doc:`content`, you'll find this implementation somewhat familiar. ``MenuNode``
 implements the above mentioned ``NodeInterface``, and holds the information
@@ -142,7 +148,7 @@ the fact that two fields exist) Content element. The ``MenuNode`` can have
 a strong (integrity ensured) or weak (integrity not ensured) reference to
 the actual Content element it points to, it's up to you to choose which best
 fits your scenario. You can find more information on references on the
-`Doctrine PHPCR documentation page <http://docs.doctrine-project.org/projects/doctrine-phpcr-odm/en/latest/reference/association-mapping.html#references>`_.
+`Doctrine PHPCR documentation page`_.
 
 ``MultilangMenuNode`` extends ``MenuNode`` with multilanguage support. It
 adds a ``locale`` field to identify which translation set it belongs to,
@@ -161,13 +167,13 @@ database:
         */
 
 For information on the available translation strategies, refer to the Doctrine
-page regarding `Multi language support in PHPCR-ODM <http://docs.doctrine-project.org/projects/doctrine-phpcr-odm/en/latest/reference/multilang.html>`_
+page regarding `Multi language support in PHPCR-ODM`_
 
 
 Admin Support
 -------------
 
-``MenuBundle`` also includes the administration panels and respective services
+The MenuBundle also includes the administration panels and respective services
 needed for integration with the backend admin tool :doc:`SonataDoctrinePhpcrAdminBundle <../bundles/doctrine_phpcr_admin>`
 
 The included administration panels will automatically available but need to be
@@ -188,5 +194,13 @@ Further Notes
 For more information on the MenuBundle of Symfony CMF, please refer to:
 
 - :doc:`../bundles/menu` for advanced details and configuration reference
-- `KnpMenuBundle`_ page for information on the bundle on which ``MenuBundle`` relies
-- `KnpMenu <https://github.com/knplabs/KnpMenu>`_ page for information on the underlying library used by ``KnpMenuBundle``
+- `KnpMenuBundle`_ page for information on the bundle on which the MenuBundle relies
+- `KnpMenu`_ page for information on the underlying library used by the KnpMenuBundle
+
+.. _`KnpMenuBundle`: https://github.com/knplabs/KnpMenuBundle
+.. _`SonataDoctrinePhpcrAdminBundle`: https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle
+.. _`KnpMenuBundle's documentation`: https://github.com/KnpLabs/KnpMenuBundle/blob/master/Resources/doc/index.md
+.. _`respective documentation page`: https://github.com/KnpLabs/KnpMenuBundle/blob/master/Resources/doc/index.md#rendering-menus
+.. _`Doctrine PHPCR documentation page`: http://docs.doctrine-project.org/projects/doctrine-phpcr-odm/en/latest/reference/association-mapping.html#references
+.. _`Multi language support in PHPCR-ODM`: http://docs.doctrine-project.org/projects/doctrine-phpcr-odm/en/latest/reference/multilang.html
+.. _`KnpMenu`: https://github.com/knplabs/KnpMenu

--- a/getting-started/routing.rst
+++ b/getting-started/routing.rst
@@ -30,16 +30,16 @@ The Solution
 In order to address these issues, a new routing system was developed, that
 takes into account the typical needs of a CMS routing:
 
-- User defined URLs;
-- Multi-site;
-- Multi-language;
-- Tree-like structure for easier management;
-- Content, Menu and Route separation for added flexibility.
+* User defined URLs;
+* Multi-site;
+* Multi-language;
+* Tree-like structure for easier management;
+* Content, Menu and Route separation for added flexibility.
 
 With these requirements in mind, the Symfony CMF Routing component was developed.
 
-The ChainRouter
----------------
+The ``ChainRouter``
+-------------------
 
 At the core of Symfony CMF's Routing component sits the ``ChainRouter``.
 It's used as a replacement for Symfony2's default routing system and, like
@@ -69,19 +69,25 @@ iterates over the configured Routers according to their configured priority:
     .. code-block:: xml
 
         <!-- app/config/config.xml -->
-        <symfony-cmf-routing-extra:config>
-            <symfony-cmf-routing-extra:chain>
-                <symfony-cmf-routing-extra:routers-by-id
-                    id="symfony-cmf-routing-extra.dynamic-router">
-                    200
-                </symfony-cmf-routing-extra:routers-by-id>
+        <?xml version="1.0" encoding="UTF-8" ?>
 
-                <symfony-cmf-routing-extra:routers-by-id
-                    id="router.default">
-                    100
-                </symfony-cmf-routing-extra:routers-by-id>
-            </symfony-cmf-routing-extra:chain>
-        </symfony-cmf-routing-extra:config>
+        <container xmlns="http://cmf.symfony.com/schema/dic/services"
+            xmlns:cmf-routing-extra="http://cmf.symfony.com/schema/dic/routingextra"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+            <cmf-routing-extra:config xmlns="http://cmf.symfony.com/schema/dic/routingextra">
+                <chain>
+                    <routers-by-id
+                        id="symfony_cmf_routing_extra.dynamic_router">
+                        200
+                    </routers-by-id>
+
+                    <routers-by-id
+                        id="router.default">
+                        100
+                    </routers-by-id>
+                </chain>
+            </cmf-routing-extra:config>
 
     .. code-block:: php
 
@@ -162,9 +168,16 @@ file:
     .. code-block:: xml
 
         <!-- app/config/config.xml -->
-        <symfony-cmf-routing-extra:config>
-            <symfony-cmf-routing-extra:dynamic enabled="true" />
-        </symfony-cmf-routing-extra:config>
+        <?xml version="1.0" encoding="UTF-8" ?>
+
+        <container xmlns="http://cmf.symfony.com/schema/dic/services"
+            xmlns:cmf-routing-extra="http://cmf.symfony.com/schema/dic/routingextra"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+            <cmf-routing-extra:config xmlns="http://cmf.symfony.com/schema/dic/routingextra">
+                <dynamic enabled="true" />
+            </cmf-routing-extra:config>
+        </container>
 
     .. code-block:: php
 
@@ -188,11 +201,10 @@ Getting the Route Object
 
 The provider to use can be configured to best suit each implementation's
 needs, and must implement the ``RouteProviderInterface``. As part of this
-bundle, an implementation for `PHPCR-ODM <https://github.com/doctrine/phpcr-odm>`_
-is provided, but you can easily create your own, as the Router itself is
-storage agnostic. The default provider loads the route at the path in the
-request and all parent paths to allow for some of the path segments being
-parameters.
+bundle, an implementation for `PHPCR-ODM`_ is provided, but you can easily
+create your own, as the Router itself is storage agnostic. The default
+provider loads the route at the path in the request and all parent paths to
+allow for some of the path segments being parameters.
 
 For more detailed information on this implementation and how you can customize
 or extend it, refer to :doc:`../bundles/routing-extra`.
@@ -219,14 +231,14 @@ A Route needs to specify which Controller should handle a specific Request.
 The ``DynamicRouter`` uses one of several possible methods to determine it
 (in order of precedence):
 
-- Explicit: The stored Route document itself can explicitly declare the target
+* Explicit: The stored Route document itself can explicitly declare the target
   Controller by specifying the '_controller' value in ``getRouteDefaults()``.
-- By alias: the Route returns a 'type' value in ``getRouteDefaults()``,
+* By alias: the Route returns a 'type' value in ``getRouteDefaults()``,
   which is then matched against the provided configuration from config.yml
-- By class: requires the Route instance to implement ``RouteObjectInterface``
+* By class: requires the Route instance to implement ``RouteObjectInterface``
   and return an object for ``getRouteContent()``. The returned class type is
   then matched against the provided configuration from config.yml.
-- Default: if configured, a default Controller will be used.
+* Default: if configured, a default Controller will be used.
 
 Apart from this, the ``DynamicRouter`` is also capable of dynamically specifying
 which Template will be used, in a similar way to the one used to determine
@@ -258,29 +270,31 @@ Here's an example on how to configure the above mentioned options:
     .. code-block:: xml
 
         <!-- app/config/config.xml -->
-        <symfony-cmf-routing-extra:config>
-            <symfony-cmf-routing-extra:dynamic
-                generic-controller="symfony_cmf_content.controllerindexAction"
-            >
-                <symfony-cmf-routing-extra:controllers-by-type
-                    type="editablestatic"
-                >
-                    sandbox_main.controller:indexAction
-                </symfony-cmf-routing-extra:controllers-by-type>
+        <?xml version="1.0" encoding="UTF-8" ?>
 
-                <symfony-cmf-routing-extra:controllers-by-class
-                    class="Symfony\Cmf\Bundle\ContentBundle\Document\StaticContent"
-                >
-                    symfony_cmf_content.controller::indexAction
-                </symfony-cmf-routing-extra:controllers-by-class>
+        <container xmlns="http://cmf.symfony.com/schema/dic/services"
+            xmlns:cmf-routing-extra="http://cmf.symfony.com/schema/dic/routingextra"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-                <symfony-cmf-routing-extra:templates-by-class
-                    alias="Symfony\Cmf\Bundle\ContentBundle\Document\StaticContent"
-                >
-                    SymfonyCmfContentBundle:StaticContent:index.html.twig
-                </symfony-cmf-routing-extra:templates-by-class>
-            </symfony-cmf-routing-extra:dynamic>
-        </symfony-cmf-routing-extra:config>
+            <cmf-routing-extra:config xmlns="http://cmf.symfony.com/schema/dic/routingextra">
+                <dynamic generic-controller="symfony_cmf_content.controllerindexAction">
+                    <controllers-by-type type="editablestatic">
+                        sandbox_main.controller:indexAction
+                    </controllers-by-type>
+
+                    <controllers-by-class
+                        class="Symfony\Cmf\Bundle\ContentBundle\Document\StaticContent"
+                    >
+                        symfony_cmf_content.controller::indexAction
+                    </controllers-by-class>
+
+                    <templates-by-class alias="Symfony\Cmf\Bundle\ContentBundle\Document\StaticContent"
+                    >
+                        SymfonyCmfContentBundle:StaticContent:index.html.twig
+                    </templates-by-class>
+                </dynamic>
+            </cmf-routing-extra:config>
+        </container>
 
     .. code-block:: php
 
@@ -351,12 +365,19 @@ is handled by a specific Controller, that can be configured like so:
     .. code-block:: xml
 
         <!-- app/config/config.xml -->
-        <symfony-cmf-routing-extra:config>
-            <symfony-cmf-routing-extra:controllers-by-class
-                class="Symfony\Cmf\Component\Routing\RedirectRouteInterface">
-                symfony_cmf_routing_extra.redirect_controller:redirectAction
-            </symfony-cmf-routing-extra:controllers-by-class>
-        </symfony-cmf-routing-extra:config>
+        <?xml version="1.0" encoding="UTF-8" ?>
+
+        <container xmlns="http://cmf.symfony.com/schema/dic/services"
+            xmlns:cmf-routing-extra="http://cmf.symfony.com/schema/dic/routingextra"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+            <cmf-routing-extra:config xmlns="http://cmf.symfony.com/schema/dic/routingextra">
+                <controllers-by-class
+                    class="Symfony\Cmf\Component\Routing\RedirectRouteInterface">
+                    symfony_cmf_routing_extra.redirect_controller:redirectAction
+                </controllers-by-class>
+            </cmf-routing-extra:config>
+        </container>
 
     .. code-block:: php
 
@@ -421,7 +442,8 @@ used to define an intro section that is the same for each project or other
 shared data. If you don't need content, you can just not set it in the
 document.
 
-For more details, see the :ref:`route document section in the RoutingExtraBundle documentation <bundle-routing-document>`.
+For more details, see the
+:ref:`route document section in the RoutingExtraBundle documentation <bundle-routing-document>`.
 
 
 Integrating with SonataAdmin
@@ -431,8 +453,8 @@ If ``sonata-project/doctrine-phpcr-admin-bundle`` is added to the composer.json
 require section, the route documents are exposed in the SonataDoctrinePhpcrAdminBundle.
 For instructions on how to configure this Bundle see :doc:`../bundles/doctrine_phpcr_admin`.
 
-By default, ``use_sonata_admin`` is automatically set based on whether
-``SonataDoctrinePhpcrAdminBundle`` is available but you can explicitly disable it
+By default, ``use_sonata_admin`` is automatically set based on whether the
+SonataDoctrinePhpcrAdminBundle is available but you can explicitly disable it
 to not have it even if sonata is enabled, or explicitly enable to get an error
 if Sonata becomes unavailable.
 
@@ -451,10 +473,17 @@ points to the root of your content documents.
     .. code-block:: xml
 
         <!-- app/config/config.xml -->
-        <symfony-cmf-routing-extra:config
-            use-sonata-admin="auto"
-            content-basepath="null"
-        />
+        <?xml version="1.0" encoding="UTF-8" ?>
+
+        <container xmlns="http://cmf.symfony.com/schema/dic/services"
+            xmlns:cmf-routing-extra="http://cmf.symfony.com/schema/dic/routingextra"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+            <cmf-routing-extra:config
+                use-sonata-admin="auto"
+                content-basepath="null"
+            />
+        </container>
 
     .. code-block:: php
 
@@ -488,7 +517,10 @@ Further Notes
 
 For more information on the Routing component of Symfony CMF, please refer to:
 
-- :doc:`../components/routing` for most of the actual functionality implementation
-- :doc:`../bundles/routing-extra` for Symfony2 integration bundle for Routing Bundle
-- Symfony2's `Routing <http://symfony.com/doc/current/components/routing/introduction.html>`_ component page
-- :doc:`../tutorials/handling-multilang-documents` for some notes on multilingual routing
+* :doc:`../components/routing` for most of the actual functionality implementation
+* :doc:`../bundles/routing-extra` for Symfony2 integration bundle for Routing Bundle
+* Symfony2's `Routing`_ component page
+* :doc:`../tutorials/handling-multilang-documents` for some notes on multilingual routing
+
+.. _`PHPCR-ODM`: https://github.com/doctrine/phpcr-odm
+.. _`Routing`: http://symfony.com/doc/current/components/routing/introduction.html

--- a/getting-started/simplecms.rst
+++ b/getting-started/simplecms.rst
@@ -15,39 +15,35 @@ These three components complement each other but are independent: they work
 without each other, allowing you to choose which ones you want to use, extend
 or ignore. In some cases, however, you might just want a simple implementation
 that gathers all those functionalities in a ready-to-go package. For that
-purpose, the ``SimpleCMSBundle`` was created.
-
+purpose, the SimpleCMSBundle was created.
 
 SimpleCMSBundle
 ---------------
 
-``SimpleCMSBundle`` is implemented on top of most of the other Symfony CMF
+The SimpleCMSBundle is implemented on top of most of the other Symfony CMF
 Bundles, combining them into a functional CMS. It's a simple solution, but
 you will find it very useful when you start implementing your own CMS using
 Symfony CMF. Whether you decide to extend or replace it, it's up to you,
 but in both cases, it's a good place to start developing your first CMS.
 
-
 Page
 ~~~~
 
-``SimpleCMSBundle`` basic content type is ``Page``. Its class declaration
+The SimpleCMSBundle basic content type is ``Page``. Its class declaration
 points out many of the features available:
 
-- It extends ``Route``, meaning it's not only a ``Content`` instance, but
-    also a ``Route``. In this case, as declared in ``getRouteContent()``, the
-    ``Route`` as an associated content, itself.
-- It implements ``RouteAwareInterface``, which means it has associated ``Route``
-    instances. As expected, and as seen in ``getRoutes()``, it has only one ``Route``
-    associated: itself.
-- It implements ``NodeInterface``, which means it can be used by ``MenuBundle``
-    to generate a menu structure.
-
+* It extends ``Route``, meaning it's not only a ``Content`` instance, but
+  also a ``Route``. In this case, as declared in ``getRouteContent()``, the
+  ``Route`` as an associated content, itself.
+* It implements ``RouteAwareInterface``, which means it has associated ``Route``
+  instances. As expected, and as seen in ``getRoutes()``, it has only one ``Route``
+  associated: itself.
+* It implements ``NodeInterface``, which means it can be used by ``MenuBundle``
+  to generate a menu structure.
 
 The class itself is similar to the ``StaticContent`` already described in
 the documentation page regarding :doc:`content`, although some key atributes,
 like ``parent`` or ``path`` come from the ``Route`` class it extends.
-
 
 Three-in-one
 ~~~~~~~~~~~~
@@ -61,7 +57,7 @@ a template which, in turn, presents the user with a HTML visualization of
 the stored information tree structure, rendered using ``MenuItem`` obtained
 from equivalent ``NodeInterface`` instances.
 
-``SimpleCMSBundle`` simplifies this process: ``Content``, ``Route`` and ``NodeInterface``
+The SimpleCMSBundle simplifies this process: ``Content``, ``Route`` and ``NodeInterface``
 are gathered in one class: ``Page``. This three-in-one approach is the key
 concept behind this bundle.
 
@@ -75,19 +71,19 @@ translated (``title``, ``label`` and ``body``). It also includes ``getStaticPref
 to handle the path prefix of the ``Page``. This is part of the route handling
 mechanism, and will be analysed bellow.
 
- The ``MultilangPage`` uses the ``attribute`` strategy for translation: the
- several translations coexist in the same database entry, and the several
- translated versions of each field are stored as different attributes in
- that same entry.
+The ``MultilangPage`` uses the ``attribute`` strategy for translation: the
+several translations coexist in the same database entry, and the several
+translated versions of each field are stored as different attributes in
+that same entry.
 
- As the routing is not separated from the content, it is not possible to
- create different routes for different languages. This is one of the biggest
- disadvantages of the ``SimpleCmsBundle``.
+As the routing is not separated from the content, it is not possible to
+create different routes for different languages. This is one of the biggest
+disadvantages of the `SimpleCmsBundle.
 
 Configuring the Content Class
 .............................
 
-By default, ``SimpleCMSBundle`` will use ``Symfony\Cmf\Bundle\SimpleCmsBundle\Document\Page``
+By default, the SimpleCMSBundle will use ``Symfony\Cmf\Bundle\SimpleCmsBundle\Document\Page``
 as the content class if multilanguage is not enabled (default). If no other
 class is chosen, and multilanguage support is enabled, it will automatically
 switch to ``Symfony\Cmf\Bundle\SimpleCmsBundle\Document\MultilangPage``.
@@ -107,13 +103,20 @@ support using the configuration parameters:
     .. code-block:: xml
 
         <!-- app/config/config.xml -->
-        <symfony-cmf-simple-cms:config
-            document-class="null"
-        >
-            <symfony-cmf-simple-cms:multilang>
-                <symfony-cmf-simple-cms:locales></symfony-cmf-simple-cms:locales>
-            </symfony-cmf-simple-cms:multilang>
-        </symfony-cmf-simple-cms:config>
+        <?xml version="1.0" encoding="UTF-8" ?>
+
+        <container xmlns="http://cmf.symfony.com/schema/dic/services"
+            xmlns:cmf-simple-cms="http://cmf.symfony.com/schema/dic/simplecms"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+            <cmf-simple-cms:config xmlns="http://cmf.symfony.com/schema/dic/simplecms"
+                document-class="null"
+            >
+                <multilang>
+                    <locales></locales>
+                </multilang>
+            </cmf-simple-cms:config>
+        </container>
 
     .. code-block:: php
 
@@ -125,36 +128,34 @@ support using the configuration parameters:
             ),
         ));
 
-
 SimpleCMSBundle in Detail
 -------------------------
 
-Now that you understand what ``SimpleCMSBundle`` does, we'll detail how it
+Now that you understand what the SimpleCMSBundle does, we'll detail how it
 does it. Several other components are part of this bundle, that change the
 default behaviour of its dependencies.
-
 
 The Routing
 ~~~~~~~~~~~
 
-``SimpleCMSBundle`` doesn't add much functionality to the routing part of
-Symfony CMF. Instead, it greatly relies on ``RoutingExtraBundle`` and its
+The SimpleCMSBundle doesn't add much functionality to the routing part of
+Symfony CMF. Instead, it greatly relies on RoutingExtraBundle and its
 set of configurable functionalities to meet its requirements. It declares
 an independent ``DynamicRouter``, with it's own specific ``RouteProvider``,
 ``NestedMatcher``, Enhancers set and other useful services, all of them instances
-of the classes bundled with ``RoutingBundle`` and ``RoutingExtraBudle``.
-This service declaration duplication allows you to reuse the original ``RoutingExtraBundle``
+of the classes bundled with RoutingBundle and RoutingExtraBudle.
+This service declaration duplication allows you to reuse the original RoutingExtraBundle
 configuration options to declare another Router, if you wish to do so.
 
-The only exception to this is ``RouteProvider``: the ``SimpleCMSBundle``
+The only exception to this is ``RouteProvider``: the SimpleCMSBundle
 has its own strategy to retrieve ``Route`` instances from database. This
-is related with the way ``Route`` instances are stored in database by ``RoutingExtraBundle``.
+is related with the way ``Route`` instances are stored in database by RoutingExtraBundle.
 By default, the ``path`` parameter will hold the prefixed full URI, including
 the locale identifier. This would mean an independent ``Route`` instance
 should exist for each translation of the same ``Content``. However, as we've
 seen, ``MultilangPage```stores all translations in the same entry. So, to
 avoid duplication, the locale prefix is stripped from the URI prior to persistance,
-and ``SimpleCMSBundle`` includes ``MultilangRouteProvider``, which is responsible
+and SimpleCMSBundle includes ``MultilangRouteProvider``, which is responsible
 for fetching ``Route`` instances taking that into account.
 
 When rendering the actual URL from ``Route``, the locale prefix needs to be
@@ -171,14 +172,12 @@ content. With the above mentioned approach, the ``locale`` is stripped from
 the URI prior to ``basepath`` prepending, resulting in a query for ``/cms/simple/contact/``
 in both cases.
 
-
 Routes and Redirections
 .......................
 
-``SimpleCMSBundle`` includes ``MultilangRoute`` and ``MultilangRedirectRoute``,
-extensions to the ``Route`` and ``RedirectRoute`` found in ``RoutingExtraBudle``,
+The SimpleCMSBundle includes ``MultilangRoute`` and ``MultilangRedirectRoute``,
+extensions to the ``Route`` and ``RedirectRoute`` found in RoutingExtraBudle,
 but with the necessary changes to handle the prefix strategy discussed earlier.
-
 
 Content Handling
 ~~~~~~~~~~~~~~~~
@@ -186,7 +185,7 @@ Content Handling
 ``Route`` instances are responsible for determining which ``Controller``
 will handle the current request. :ref:`start-routing-getting-controller-template`
 shows how Symfony CMF SE can determine which ``Controller`` to use when rendering
-a certain content, and ``SimpleCMSBundle`` uses these mechanisms to do so.
+a certain content, and the SimpleCMSBundle uses these mechanisms to do so.
 
 .. configuration-block::
 
@@ -199,9 +198,16 @@ a certain content, and ``SimpleCMSBundle`` uses these mechanisms to do so.
     .. code-block:: xml
 
         <!-- app/config/config.xml -->
-        <symfony-cmf-simple-cms:config
-            generic-controller="null"
-        />
+        <?xml version="1.0" encoding="UTF-8" ?>
+
+        <container xmlns="http://cmf.symfony.com/schema/dic/services"
+            xmlns:cmf-simple-cms="http://cmf.symfony.com/schema/dic/simplecms"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+            <cmf-simple-cms:config
+                generic-controller="null"
+            />
+        </container>
 
     .. code-block:: php
 
@@ -233,19 +239,26 @@ default configuration.
     .. code-block:: xml
 
         <!-- app/config/config.xml -->
-        <symfony-cmf-simple-cms:config>
-            <symfony-cmf-simple-cms:routing>
-                <symfony-cmf-simple-cms:templates-by-class
-                    alias="Symfony\Cmf\Bundle\SimpleCmsBundle\Document\Page">
-                    SymfonyCmfSimpleCmsBundle:Page:index.html.twig
-                </symfony-cmf-simple-cms:templates-by-class
+        <?xml version="1.0" encoding="UTF-8" ?>
 
-                <symfony-cmf-simple-cms:controllers-by-class
-                    alias="Symfony\Cmf\Bundle\RoutingExtraBundle\Document\RedirectRoute">
-                    symfony_cmf_routing_extra.redirect_controller:redirectAction
-                </symfony-cmf-simple-cms:templates-by-class
-            </symfony-cmf-simple-cms:routing>
-        </symfony-cmf-simple-cms:config>
+        <container xmlns="http://cmf.symfony.com/schema/dic/services"
+            xmlns:cmf-simple-cms="http://cmf.symfony.com/schema/dic/simplecms"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+            <cmf-simple-cms:config xmlns="http://cmf.symfony.com/schema/dic/simplecms"
+                <routing>
+                    <templates-by-class
+                        alias="Symfony\Cmf\Bundle\SimpleCmsBundle\Document\Page">
+                        SymfonyCmfSimpleCmsBundle:Page:index.html.twig
+                    </templates-by-class
+
+                    <controllers-by-class
+                        alias="Symfony\Cmf\Bundle\RoutingExtraBundle\Document\RedirectRoute">
+                        symfony_cmf_routing_extra.redirect_controller:redirectAction
+                    </templates-by-class
+                </routing>
+            </cmf-simple-cms:config>
+        </container>
 
     .. code-block:: php
 
@@ -269,7 +282,7 @@ provided by the associated ``Route`` (which, in this case, is ``Page`` itself).
 It also states that all contents that instantiate ``RedirectRoute`` will
 be rendered using the mentioned ``Controller`` instead of the default. Again,
 the actual ``Route`` can provided a controller, in will take priority over
-this one. Both the template and the controller are part of ``SimpleCMSBundle``.
+this one. Both the template and the controller are part of SimpleCMSBundle.
 
 
 Menu Generation
@@ -280,7 +293,7 @@ it can be used to generate ``MenuItem`` that will, in turn, be rendered into
 HTML menus presented to the user.
 
 To do so, the default ``MenuBundle`` mechanisms are used, only a custom ``basepath``
-is provided to the ``PHPCRMenuProvider`` instance. This is defined in ``SimpleCMSBundle``
+is provided to the ``PHPCRMenuProvider`` instance. This is defined in the SimpleCMSBundle
 configuration options, and used when handling content storage, to support
 functionality as described in :doc:`menu` documentation. This parameter is
 optional, can be configured like so:
@@ -297,10 +310,17 @@ optional, can be configured like so:
     .. code-block:: xml
 
         <!-- app/config/config.xml -->
-        <symfony-cmf-simple-cms:config
-            use-menu="null"
-            basepath="null"
-        />
+        <?xml version="1.0" encoding="UTF-8" ?>
+
+        <container xmlns="http://cmf.symfony.com/schema/dic/services"
+            xmlns:cmf-simple-cms="http://cmf.symfony.com/schema/dic/simplecms"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+            <cmf-simple-cms:config
+                use-menu="null"
+                basepath="null"
+            />
+        </container>
 
     .. code-block:: php
 
@@ -314,13 +334,13 @@ optional, can be configured like so:
 Admin Support
 -------------
 
-``SimpleCMSBundle`` also includes the administration panel and respective
-service needed for integration with `SonataDoctrinePHPCRAdminBundle <https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle>`_,
+The SimpleCMSBundle also includes the administration panel and respective
+service needed for integration with `SonataDoctrinePHPCRAdminBundle`_,
 a backoffice generation tool that can be installed with Symfony CMF. For
-more information about it, please refer to the bundle's `documentation section <https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/tree/master/Resources/doc>`_.
+more information about it, please refer to the bundle's `documentation section`_.
 
-The included administration panels will automatically be loaded if you install
-``SonataDoctrinePHPCRAdminBundle`` (refer to :doc:`../tutorials/creating-cms-using-cmf-and-sonata`
+The included administration panels will automatically be loaded if you install the
+SonataDoctrinePHPCRAdminBundle (refer to :doc:`../tutorials/creating-cms-using-cmf-and-sonata`
 for instructions on how to do so). You can change this behaviour with the
 following configuration option:
 
@@ -335,9 +355,16 @@ following configuration option:
     .. code-block:: xml
 
         <!-- app/config/config.xml -->
-        <symfony-cmf-simple-cms:config
-            use-sonata-admin="null"
-        />
+        <?xml version="1.0" encoding="UTF-8" ?>
+
+        <container xmlns="http://cmf.symfony.com/schema/dic/services"
+            xmlns:cmf-simple-cms="http://cmf.symfony.com/schema/dic/simplecms"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+            <cmf-simple-cms:config
+                use-sonata-admin="null"
+            />
+        </container>
 
     .. code-block:: php
 
@@ -350,7 +377,7 @@ following configuration option:
 Fixtures
 --------
 
-``SimpleCMSBundle`` includes a support class for integration with `DoctrineFixturesBundle <http://symfony.com/doc/master/bundles/DoctrineFixturesBundle/index.html>`_,
+The SimpleCMSBundle includes a support class for integration with `DoctrineFixturesBundle`_,
 aimed at making loading initial data easier. A working example is provided
 in Symfony CMF SE, that illustrates how you can easily generate ``MultilangPage``
 and ``MultilangMenuNode`` instances from yml files.
@@ -368,11 +395,15 @@ Further Notes
 
 For more information on the SimpleCMSBundle, please refer to:
 
-- :doc:`../bundles/simple-cms` for configuration reference and advanced details
+* :doc:`../bundles/simple-cms` for configuration reference and advanced details
   about the bundle.
-- :doc:`../getting-started/routing` for information about the routing component
-  in which ``SimpleCMSBundle`` is based on.
-- :doc:`../getting-started/content` for information about the base content
-  bundle that ``SimpleCMSBundle`` depends on.
-- :doc:`../getting-started/menu` for information about the menu system used
-  by ``SimpleCMSBundle``.
+* :doc:`../getting-started/routing` for information about the routing component
+  in which the SimpleCMSBundle is based on.
+* :doc:`../getting-started/content` for information about the base content
+  bundle that the SimpleCMSBundle depends on.
+* :doc:`../getting-started/menu` for information about the menu system used
+  by the SimpleCMSBundle.
+
+.. _`SonataDoctrinePHPCRAdminBundle`: https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle
+.. _`documentation section`: https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/tree/master/Resources/doc
+.. _`DoctrineFixturesBundle`: http://symfony.com/doc/master/bundles/DoctrineFixturesBundle/index.html


### PR DESCRIPTION
This includes:
- The XML format @dbu and I discussed earlier (see https://github.com/symfony-cmf/symfony-cmf-docs/pull/113/files#r3886994 )
- Removing literals from bundle names. Literals should only be used for classes, paths, methods, code related things, ect. **not** for bundle names. (this is discussed with @dantleech on IRC)
- Changing inline hyperlinks to target hyperlinks
- Using `*` for list items (`-` is not officially supported by ReSt)
