### PR TITLE
Fixed issues at Components map

### DIFF
--- a/components/map.rst.inc
+++ b/components/map.rst.inc
@@ -1,3 +1,3 @@
 * **Routing**
 
-    * :doc:`components/routing`
+  * :doc:`/cmf/components/routing`


### PR DESCRIPTION
This PR fixes the remaining issues in the Components map. I also tried using `/cms/` as a prefix to absolute urls.
