### PR TITLE
Fixed xml namespaces

### DIFF
--- a/bundles/block/types.rst
+++ b/bundles/block/types.rst
@@ -72,16 +72,15 @@ define the imagine filter you specify in the block. The default name is
 
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
-        <container xmlns="http://symfony.com/schema/dic/services"
-            xmlns:liip-imagine="http://example.org/dic/schema/liip_imagine">
+        <container xmlns="http://symfony.com/schema/dic/services">
 
-            <liip-imagine:config xmlns="http://example.org/dic/schema/liip_imagine">
+            <config xmlns="http://example.org/dic/schema/liip_imagine">
                 <!-- ... -->
                 <filter-set name="cmf_block" data-loader="phpcr" quality="85">
                     <filter name="thumbnail" size="616,419" mode="outbound"/>
                 </filter-set>
                 <!-- ... -->
-            </liip-imagine:config>
+            </config>
         </container>
 
     .. code-block:: php

--- a/bundles/menu.rst
+++ b/bundles/menu.rst
@@ -181,15 +181,14 @@ explicitly:
 
     .. code-block:: xml
 
-        <container xmlns="http://symfony.com/schema/dic/services"
-            xmlns:cmf-menu="http://cmf.symfony.com/schema/dic/menu">
-            <cmf-menu:config xmlns="http://cmf.symfony.com/schema/dic/menu">
+        <container xmlns="http://symfony.com/schema/dic/services">
+            <config xmlns="http://cmf.symfony.com/schema/dic/menu">
                 <voter>
                     <content-identity>
                         <content-key>myKey</content-key>
                     </content-identity>
                 </voter>
-            </cmf-menu:config>
+            </config>
         </container>
 
     .. code-block:: php

--- a/bundles/phpcr_odm.rst
+++ b/bundles/phpcr_odm.rst
@@ -510,9 +510,11 @@ correct.
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping
                 http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+
             <class name="Symfony\Cmf\Bundle\RoutingBundle\Document\Route">
                 <constraint name="Doctrine\Bundle\PHPCRBundle\Validator\Constraints\ValidPhpcrOdm" />
             </class>
+
         </constraint-mapping>
 
 

--- a/cookbook/using_a_custom_route_repository.rst
+++ b/cookbook/using_a_custom_route_repository.rst
@@ -99,16 +99,13 @@ configuration as follows:
 
        <!-- app/config/config.xml -->
        <?xml version="1.0" encoding="UTF-8" ?>
-       <container xmlns="http://symfony.com/schema/dic/services"
-           xmlns:cmf-routing="http://cmf.symfony.com/schema/dic/routing"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-           <cmf-routing:config xmlns="http://cmf.symfony.com/schema/dic/routing">
+       <container xmlns="http://symfony.com/schema/dic/services">
+           <config xmlns="http://cmf.symfony.com/schema/dic/routing">
                <dynamic
                    enabled="true"
                    route-provider-service-id="my_bundle.provider.endpoint"
                />
-           </cmf-routing:config>
+           </config>
        </container>
 
    .. code-block:: php

--- a/getting_started/routing.rst
+++ b/getting_started/routing.rst
@@ -74,11 +74,9 @@ their configured priority:
         <!-- app/config/config.xml -->
         <?xml version="1.0" encoding="UTF-8" ?>
 
-        <container xmlns="http://cmf.symfony.com/schema/dic/services"
-            xmlns:cmf-routing="http://cmf.symfony.com/schema/dic/routing"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <container xmlns="http://cmf.symfony.com/schema/dic/services">
 
-            <cmf-routing:config xmlns="http://cmf.symfony.com/schema/dic/routing">
+            <config xmlns="http://cmf.symfony.com/schema/dic/routing">
                 <chain>
                     <!-- enable the DynamicRouter with high priority to allow overwriting
                          configured routes with content -->
@@ -93,7 +91,7 @@ their configured priority:
                         100
                     </routers-by-id>
                 </chain>
-            </cmf-routing:config>
+            </config>
 
     .. code-block:: php
 
@@ -179,12 +177,11 @@ by default. To activate it, just add the following to your configuration file:
         <?xml version="1.0" encoding="UTF-8" ?>
 
         <container xmlns="http://cmf.symfony.com/schema/dic/services"
-            xmlns:cmf-routing="http://cmf.symfony.com/schema/dic/routing"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-            <cmf-routing:config xmlns="http://cmf.symfony.com/schema/dic/routing">
+            <config xmlns="http://cmf.symfony.com/schema/dic/routing">
                 <dynamic enabled="true" />
-            </cmf-routing:config>
+            </config>
         </container>
 
     .. code-block:: php
@@ -282,10 +279,9 @@ Here's an example of how to configure the above mentioned options:
         <?xml version="1.0" encoding="UTF-8" ?>
 
         <container xmlns="http://cmf.symfony.com/schema/dic/services"
-            xmlns:cmf-routing="http://cmf.symfony.com/schema/dic/routing"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-            <cmf-routing:config xmlns="http://cmf.symfony.com/schema/dic/routing">
+            <config xmlns="http://cmf.symfony.com/schema/dic/routing">
                 <dynamic generic-controller="cmf_content.controllerindexAction">
                     <controllers-by-type type="editablestatic">
                         sandbox_main.controller:indexAction
@@ -302,7 +298,7 @@ Here's an example of how to configure the above mentioned options:
                         CmfContentBundle:StaticContent:index.html.twig
                     </templates-by-class>
                 </dynamic>
-            </cmf-routing:config>
+            </config>
         </container>
 
     .. code-block:: php
@@ -378,15 +374,14 @@ configured as follows:
         <?xml version="1.0" encoding="UTF-8" ?>
 
         <container xmlns="http://cmf.symfony.com/schema/dic/services"
-            xmlns:cmf-routing="http://cmf.symfony.com/schema/dic/routing"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-            <cmf-routing:config xmlns="http://cmf.symfony.com/schema/dic/routing">
+            <config xmlns="http://cmf.symfony.com/schema/dic/routing">
                 <controllers-by-class
                     class="Symfony\Cmf\Component\Routing\RedirectRouteInterface">
                     cmf_routing.redirect_controller:redirectAction
                 </controllers-by-class>
-            </cmf-routing:config>
+            </config>
         </container>
 
     .. code-block:: php

--- a/getting_started/simplecms.rst
+++ b/getting_started/simplecms.rst
@@ -110,18 +110,17 @@ using the configuration parameters:
         <?xml version="1.0" encoding="UTF-8" ?>
 
         <container xmlns="http://cmf.symfony.com/schema/dic/services"
-            xmlns:cmf-simple-cms="http://cmf.symfony.com/schema/dic/simplecms"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
             <!-- defaults to Symfony\Cmf\Bundle\SimpleCmsBundle\Document\Page or MultilangPage (see above) -->
-            <cmf-simple-cms:config xmlns="http://cmf.symfony.com/schema/dic/simplecms"
+            <config xmlns="http://cmf.symfony.com/schema/dic/simplecms"
                 document-class="null"
             >
                 <multilang>
                     <!-- defaults to empty list - declare your locales here to enable multilanguage -->
                     <locales></locales>
                 </multilang>
-            </cmf-simple-cms:config>
+            </config>
         </container>
 
     .. code-block:: php
@@ -253,10 +252,9 @@ type. Symfony CMF SE includes an example of both in its default configuration.
         <?xml version="1.0" encoding="UTF-8" ?>
 
         <container xmlns="http://cmf.symfony.com/schema/dic/services"
-            xmlns:cmf-simple-cms="http://cmf.symfony.com/schema/dic/simplecms"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
-            <cmf-simple-cms:config xmlns="http://cmf.symfony.com/schema/dic/simplecms"
+            <config xmlns="http://cmf.symfony.com/schema/dic/simplecms"
                 <routing>
                     <templates-by-class
                         alias="Symfony\Cmf\Bundle\SimpleCmsBundle\Document\Page">
@@ -268,7 +266,7 @@ type. Symfony CMF SE includes an example of both in its default configuration.
                         cmf_routing.redirect_controller:redirectAction
                     </templates-by-class
                 </routing>
-            </cmf-simple-cms:config>
+            </config>
         </container>
 
     .. code-block:: php


### PR DESCRIPTION
I just discovered I did something completely wrong in the XML examples. Instead of:

``` xml
<container xmlns="..."
    xmlns:cmf-search="http://cmf.symfony.com/schema/dic/search">

    <cmf-search:config xmlns="http://cmf.symfony.com/schema/dic/search">
        <search-fields
            foo="bar"
        />
    </cmf-search:config>
</container>
```

It should be:

``` xml
<container xmlns="...">

    <config xmlns="http://cmf.symfony.com/schema/dic/search">
        <search-fields
            foo="bar"
        />
    </config>
</container>
```

This PR fixes that, I'm going to merge it soon if nobody comments.
