### PR TITLE
updated configuration param for BlockBundle

### DIFF
--- a/bundles/block/introduction.rst
+++ b/bundles/block/introduction.rst
@@ -31,7 +31,7 @@ The configuration key for this bundle is ``cmf_block``:
 
         # app/config/config.yml
         cmf_block:
-            document_manager_name:  default
+            manager_name:  default
 
     .. code-block:: xml
 


### PR DESCRIPTION
The `document_manager_name` parameter is now called `manager_name` - this reflects that change.
