### PR TITLE
fix format names

### DIFF
--- a/bundles/block/cache.rst
+++ b/bundles/block/cache.rst
@@ -222,7 +222,7 @@ your Twig template when using cache:
             extra_cache_keys: { 'extra_key': 'my_block' }
         }) }}
 
-    .. code-block:: php+html
+    .. code-block:: html+php
 
         <?php echo $view['blocks']->render(array(
             'name' => 'rssBlock',
@@ -245,7 +245,7 @@ When using the Esi, Ssi or Js cache adapters the settings passed here are rememb
             'maxItems': 2
         }) }}
 
-    .. code-block:: php+html
+    .. code-block:: html+php
 
         <?php echo $view['blocks']->render(array(
             'name' => 'rssBlock',

--- a/bundles/block/introduction.rst
+++ b/bundles/block/introduction.rst
@@ -242,7 +242,7 @@ Example of how settings can be specified through a template helper:
             'url': 'http://cmf.symfony.com/news.rss'
         }) }}
 
-    .. code-block:: php+html
+    .. code-block:: html+php
         
         <?php $view['blocks']->render(array('name' => 'rssBlock'), array(
             'title' => 'Symfony2 CMF news',
@@ -277,7 +277,7 @@ to render them:
         {{ sonata_block_include_javascripts() }}
         {{ sonata_block_include_stylesheets() }}
 
-    .. code-block:: php+html
+    .. code-block:: html+php
 
         <?php $view['blocks']->includeJavaScripts() ?>
         <?php $view['blocks']->includeStylesheets() ?>
@@ -307,7 +307,7 @@ the following code to your Twig template:
 
         {{ sonata_block_render({'name': '/cms/content/blocks/sidebarBlock'}) }}
 
-    .. code-block:: php+html
+    .. code-block:: html+php
 
         <?php echo $view['blocks']->render(array(
             'name' => '/cms/content/blocks/sidebarBlock',
@@ -323,7 +323,7 @@ as follows:
 
         {{ sonata_block_render({'name': 'sidebarBlock'}) }}
 
-    .. code-block:: php+html
+    .. code-block:: html+php
 
         <?php echo $view['blocks']->render(array(
             'name' => 'sidebarBlock',

--- a/bundles/block/types.rst
+++ b/bundles/block/types.rst
@@ -245,7 +245,7 @@ contains a ``SlideshowBlock`` object, you can simply render it with:
             'name': 'slideshow'
         }) }}
 
-    .. code-block:: php+html
+    .. code-block:: html+php
 
         <?php echo $view['blocks']->render(array(
             'name' => 'slideshow',

--- a/bundles/tree_browser.rst
+++ b/bundles/tree_browser.rst
@@ -239,7 +239,7 @@ Here is a simple way to remove the context menu from the admin tree (add the
 
 .. configuration-block::
 
-    .. code-block:: jinja+html
+    .. code-block:: html+jinja
 
         {% render 'sonata.admin.doctrine_phpcr.tree_controller:treeAction' with {
             'root':     websiteId ~ "/menu",
@@ -257,7 +257,7 @@ Here is a simple way to remove the context menu from the admin tree (add the
             });
         </script>
 
-    .. code-block:: php+html
+    .. code-block:: html+php
 
         <?php
         $view['actions']->render('sonata.admin.doctrine_phpcr.tree_controller:treeAction', array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

There are no Pygments lexers for php+html (should be html+php) and jinja+html (should be html+jinja) (s. [the build errors](http://symfony.com/doc/build_errors)).
