### PR TITLE
Added base/normal documents and standard features

### DIFF
--- a/contributing/bundles.rst
+++ b/contributing/bundles.rst
@@ -105,7 +105,7 @@ Persistence
 
 All CMF bundles:
 
-* MUST support PHPCR-ODM;
+* MUST support PHPCR-ODM for persistence;
 * MAY support other persistence layers like Doctrine ORM;
 * MUST follow the following structure to enable future or
   current support of other persistence systems:
@@ -136,7 +136,7 @@ information.
 Base and Standard Implementations
 ---------------------------------
 
-The CMF offers various features which which add functionality beyond the basic
+The CMF offers various features which add functionality beyond the basic
 use case of some classes. Examples of these features include multi-language
 and publish workflow support, but the potential list of features is unbounded.
 
@@ -162,7 +162,7 @@ Standard CMF Features
 CMF Bundles MUST (where applicable) implement the following features:
 
 * PublishWorkflow;
-* Multiple language support.
+* Translatable support.
 
 Configuration, Files and Formats
 --------------------------------


### PR DESCRIPTION
ok, so this is yet another alternative to the already discused **FullFeatures** approach.

This one is better suited to things like the `BlockBundle` where we don't necesisarily want to have 20 documents instead of 10. By default documents would be _feature complete_, but important documents should extend a `Base` document as described in this proposal.

This has the downside that we cannot type-check for an "Advanced" document - but this shouldn't matter in the long term as we should be checking for the existance of individual features.
