### PR TITLE
use spaces instead of tabs for indentation

### DIFF
--- a/contributing/index.rst
+++ b/contributing/index.rst
@@ -2,7 +2,7 @@ Contributing
 ============
 
 .. toctree::
-	:hidden:
+    :hidden:
 
     code
     bundles


### PR DESCRIPTION
otherwise the toctree isn't hidden
