### PR TITLE
Removed Bundle files from exclude list

### DIFF
--- a/components/testing.rst
+++ b/components/testing.rst
@@ -52,7 +52,6 @@ named ``phpunit.xml.dist``:
                 <directory>.</directory>
                 <exclude>
                     <directory>Resources/</directory>
-                    <directory>Admin/</directory>
                     <directory>Tests/</directory>
                     <directory>vendor/</directory>
                 </exclude>


### PR DESCRIPTION
According to a discussion in https://github.com/symfony-cmf/BlockBundle/pull/99 that file shouldn't be excluded by default.
