### PR TITLE
Fix reference to SimpleCmsBundle\Document\Page in document_tree config

### DIFF
--- a/tutorials/creating_cms_using_cmf_and_sonata.rst
+++ b/tutorials/creating_cms_using_cmf_and_sonata.rst
@@ -106,20 +106,15 @@ Add the sonata bundles to your application configuration:
                 Symfony\Cmf\Bundle\SimpleCmsBundle\Doctrine\Phpcr\Page:
                     valid_children:
                         - all
-                Symfony\Cmf\Bundle\RoutingBundle\Document\Route:
+                Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\Route:
                     valid_children:
-                        - Symfony\Cmf\Bundle\RoutingBundle\Document\Route
-                        - Symfony\Cmf\Bundle\RoutingBundle\Document\RedirectRoute
-                Symfony\Cmf\Bundle\RoutingBundle\Document\RedirectRoute:
+                        - Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\Route
+                        - Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\RedirectRoute
+                Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\RedirectRoute:
                     valid_children: []
-                Symfony\Cmf\Bundle\MenuBundle\Document\MenuNode:
+                Symfony\Cmf\Bundle\MenuBundle\Doctrine\Phpcr\MenuNode:
                     valid_children:
-                        - Symfony\Cmf\Bundle\MenuBundle\Document\MenuNode
-                        - Symfony\Cmf\Bundle\MenuBundle\Document\MultilangMenuNode
-                Symfony\Cmf\Bundle\MenuBundle\Document\MultilangMenuNode:
-                    valid_children:
-                        - Symfony\Cmf\Bundle\MenuBundle\Document\MenuNode
-                        - Symfony\Cmf\Bundle\MenuBundle\Document\MultilangMenuNode
+                        - Symfony\Cmf\Bundle\MenuBundle\Doctrine\Phpcr\MenuNode
 
 Add route in to your routing configuration:
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | [e77a72b0c7999509be31852e838e156632ca85fd and above](https://github.com/symfony-cmf/SimpleCmsBundle/commit/e77a72b0c7999509be31852e838e156632ca85fd) |
| Fixed tickets | https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/issues/168 |

The config for the sonata_admin_phpcr_admin.document_tree contained a mapping for a class which has been removed (SimpleCmsBundle\Document\Page). This class has been replaced with 
Symfony\Cmf\Bundle\SimpleCmsBundle\Doctrine\Phpcr\Page and this mapping is required in order for Sonata Admin to display and allow editing of the default documents created by the SimpleCmsBundle in the PHPCR.
