### PR TITLE
Explain how multilang works

### DIFF
--- a/bundles/core/multilang.rst
+++ b/bundles/core/multilang.rst
@@ -1,8 +1,16 @@
 .. index::
     single: Multi-Language; CoreBundle
 
+
 Multi-language support
 ----------------------
+
+.. _bundles-core-multilang-persisting_multilang_documents:
+
+Persisting Documents in Different Languages
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Refer to the `PHPCR-ODM documentation`_ for details on persisting documents in different languages.
 
 Editing Locale Information: Translatable Sonata Admin Extension
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -60,3 +68,4 @@ configuration in the ``sonata_admin`` section of your project configuration:
 See the `Sonata Admin extension documentation`_ for more information.
 
 .. _`Sonata Admin extension documentation`: http://sonata-project.org/bundles/admin/master/doc/reference/extensions.html
+.. _`PHPCR ODM documentation`: http://docs.doctrine-project.org/projects/doctrine-phpcr-odm/en/latest/reference/multilang.html#full-example


### PR DESCRIPTION
I am confused about how persiting multilang docs in the CMF actually works..

In the MenuBundle documentation I wanted to link to the CoreBundle multilang docuemntation, and explain how to persist docs there, but then it made sense to link to the PHPCR-ODM docs which use `bindTranslation`.

But then the `TranslatableInterface` has `setLocale`, so do we need to call `bindTranslation` ? Is `locale` read only? Will calling `setLocale` do anything?

Anyway, we should make all this clear here.
