### PR TITLE
Removed the doctrine_phpcr_admin_bundle_odm route

### DIFF
--- a/cookbook/creating_cms_using_cmf_and_sonata.rst
+++ b/cookbook/creating_cms_using_cmf_and_sonata.rst
@@ -137,9 +137,6 @@ Add route in to your routing configuration:
             type: sonata_admin
             prefix: /admin
 
-        doctrine_phpcr_admin_bundle_odm_browser:
-            resource: "@SonataDoctrinePHPCRAdminBundle/Resources/config/routing/phpcrodmbrowser.xml"
-
         fos_js_routing:
             resource: "@FOSJsRoutingBundle/Resources/config/routing/routing.xml"
 


### PR DESCRIPTION
Removed the doctrine_phpcr_admin_bundle_odm route as this seems to be no longer needed, nor does this xml file exist.
