### PR TITLE
Make PHP the highlighting language by default

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -259,3 +259,6 @@ texinfo_documents = [
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
+
+# Use PHP syntax highlighting in code examples by default
+highlight_language='php'


### PR DESCRIPTION
Use syntax highlghting by default for code examples when building locally

I guess this conf.py file is not used when building the main SF docs.
