### PR TITLE
Missing namespace import

### DIFF
--- a/cookbook/create_basic_cms_auto_routing.rst
+++ b/cookbook/create_basic_cms_auto_routing.rst
@@ -214,6 +214,7 @@ The ``Page`` class is therefore nice and simple::
     namespace Acme\BasicCmsBundle\Document;
 
     use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCR;
+    use Symfony\Cmf\Component\Routing\RouteReferrersReadInterface;
 
     /**
      * @PHPCR\Document(referenceable=true)


### PR DESCRIPTION
without this namespace
the doctrine:phpcr:fixtures:load command fail with a 
PHP Fatal error:  Interface 'Acme\BasicCmsBundle\Document\RouteReferrersReadInterface' not found
