### PR TITLE
Fixed save location instruction for page.html.twig

### DIFF
--- a/cookbook/create_basic_cms_auto_routing.rst
+++ b/cookbook/create_basic_cms_auto_routing.rst
@@ -1184,7 +1184,7 @@ Add a corresponding twig template (note that this works because you use the
 
     .. code-block:: html+jinja
 
-        {# src/Acme/BasicCmsBundle/Resources/veiws/Default/page.html.twig #}
+        {# src/Acme/BasicCmsBundle/Resources/views/Default/page.html.twig #}
         <h1>{{ page.title }}</h1>
         <p>{{ page.content|raw }}</p>
         <h2>Our Blog Posts</h2>


### PR DESCRIPTION
in Part: 4 The Frontend of The Cookbook.

fixes #331 
