### PR TITLE
Add the SonataCoreBundle reference

### DIFF
--- a/cookbook/create_basic_cms_auto_routing.rst
+++ b/cookbook/create_basic_cms_auto_routing.rst
@@ -763,6 +763,7 @@ Enable the Sonata related bundles to your kernel::
         {
             $bundles = array(
                 // ...
+                new Sonata\CoreBundle\SonataCoreBundle(),
                 new Sonata\BlockBundle\SonataBlockBundle(),
                 new Sonata\jQueryBundle\SonatajQueryBundle(),
                 new Knp\Bundle\MenuBundle\KnpMenuBundle(),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | none |

The sonata team recently factored some sonata bundles part into a `SonataCoreBundle` which is now required.
This PR add it on the documentation.
