### PR TITLE
Fix: Can't load PHPCR DataFixtures

### DIFF
--- a/cookbook/create_basic_cms_auto_routing.rst
+++ b/cookbook/create_basic_cms_auto_routing.rst
@@ -691,8 +691,9 @@ Now you will need to include this configuration:
     
     .. code-block:: yaml
 
-        # src/Acme/BasicCmsBundle/Resources/config/config.yml
+        # app/config/config.yml
         imports:
+            // ...
             - { resource: routing_auto.yml }
 
     .. code-block:: xml


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all (or 2.3+) |
| Fixed tickets | no |

I had to add these changes in order to load the data fixtures without errors.
