### PR TITLE
note: re-initialize repository after reload fixtures

### DIFF
--- a/cookbook/create_basic_cms_auto_routing.rst
+++ b/cookbook/create_basic_cms_auto_routing.rst
@@ -1744,8 +1744,6 @@ and verify that the ``cms`` node has been updated by using the
     Alternatively you can modify your data fixtures to create a site document
     - its up to you.
 
-
-
 Create the Make Homepage Button
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This note will be helpful anyone who doesn't know they might want to initialize the repository nodes after they reload the data fixtures.

With the above change I followed this tutorial to the end and all the steps work as expected.
So this PR would close #322.

Thanks.
