### PR TITLE
Added reference for core admin extensions

### DIFF
--- a/bundles/core/persistence.rst
+++ b/bundles/core/persistence.rst
@@ -102,6 +102,8 @@ enforce a single translation strategy for all documents:
 
 See the `PHPCR-ODM documentation`_ for more information.
 
+.. _bundle-core-translatable-admin-extension:
+
 Editing Locale Information: Translatable Sonata Admin Extension
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -129,7 +131,6 @@ configuration in the ``sonata_admin`` section of your project configuration:
         <!-- app/config/config.xml -->
         <?xml version="1.0" charset="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/services">
-
             <config xmlns="http://sonata-project.org/schema/dic/admin">
                 <!-- ... -->
                 <extension id="cmf_core.admin_extension.translatable">

--- a/bundles/core/publish_workflow.rst
+++ b/bundles/core/publish_workflow.rst
@@ -358,6 +358,8 @@ This means that custom templates for ``templates_by_class`` and the controllers
 of ``controllers_by_class`` need not check for publication explicitly as its
 already done.
 
+.. _bundle-core-workflow-admin-extensions:
+
 Editing publication information: Publish Workflow Sonata Admin Extension
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/reference/configuration/core.rst
+++ b/reference/configuration/core.rst
@@ -252,31 +252,40 @@ only published routes and content can be accessed.
 Sonata Admin
 ------------
 
-This section configures each of the Sonata Admin extensions.
+This section configures the Sonata Admin Extensions, see:
 
+* :ref:`Publish Workflow Admin Extensions <bundle-core-workflow-admin-extensions>`;
+* :ref:`Translatable Admin Extension <bundle-core-translatable-admin-extension>`.
 
 .. configuration-block::
 
     .. code-block:: yaml
 
-        sonata_admin:
-            extensions:
-                publishable:
-                    form_group:           form.group_publish_workflow
-                publish_time:
-                    form_group:           form.group_general
-                translatable:
-                    form_group:           form.group_general
+        cmf_core:
+            sonata_admin:
+                extensions:
+                    publishable:
+                        form_group: form.group_publish_workflow
+                    publish_time:
+                        form_group: form.group_general
+                    translatable:
+                        form_group: form.group_general
 
     .. code-block:: xml
 
-        <sonata-admin>
-            <extension>
-                <publishable form-group="form.group_publish_workflow" />
-                <publish-time form-group="form.group_general" />
-                <translatable form-group="form.group_general" />
-            </extension>
-        </sonata-admin>
+        <?xml version="1.0" charset="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services">
+
+            <config xmlns="http://cmf.symfony.com/schema/dic/core">
+                <sonata-admin>
+                    <extension>
+                        <publishable form-group="form.group_publish_workflow" />
+                        <publish-time form-group="form.group_general" />
+                        <translatable form-group="form.group_general" />
+                    </extension>
+                </sonata-admin>
+            </config>
+        </container>
 
     .. code-block:: php
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | no |
| New docs? | yes |
| Applies to | all (or 2.3+) |
| Fixed tickets |  |

Reference for https://github.com/symfony-cmf/CoreBundle/pull/110/files
