### PR TITLE
[RoutingAutoBundle] Fix C/P error in YAML example

### DIFF
--- a/bundles/routing_auto/customization.rst
+++ b/bundles/routing_auto/customization.rst
@@ -117,7 +117,7 @@ It is registered in the DI configuration as follows:
                 class: Symfony\Cmf\Bundle\RoutingAutoBundle\RoutingAuto\PathNotExists\ThrowException
                 scope: prototype
                 tags:
-                    - { name: cmf_routing_auto.provider, alias: "throw_exception"}
+                    - { name: cmf_routing_auto.not_exists_action, alias: "throw_exception"}
 
     .. code-block:: xml
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | N/A |

All the other examples (XML and PHP) use `cmf_routing_auto.not_exists_action` so I guess it's just a copy/paste error...
