### PR TITLE
Add repository:init command

### DIFF
--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -61,6 +61,7 @@ extension. After that, run these commands:
 
     $ php app/console doctrine:database:create
     $ php app/console doctrine:phpcr:init:dbal
+    $ php app/console doctrine:phpcr:repository:init
     $ php app/console doctrine:phpcr:fixtures:load
 
 .. tip::


### PR DESCRIPTION
The command is required to prevent the error:

```
 [Doctrine\ODM\PHPCR\PHPCRException]
 Register phpcr:managed node type first. See https://github.com/doctrine/phpcr-odm/wiki/Custom-node-type-phpcr:managed
```
