### PR TITLE
[WCM] Removed references to content object

### DIFF
--- a/bundles/routing_auto/introduction.rst
+++ b/bundles/routing_auto/introduction.rst
@@ -112,7 +112,7 @@ The configuration for the example above could be as follows:
 
                         # corresponds second path unit in diagram: my-category
                         category_path:
-                            provider: [content_object, { method: getCategory }]
+                            provider: [content_method, { method: getCategoryName }]
                             exists_action: use
                             not_exists_action: throw_exception
 
@@ -142,8 +142,8 @@ The configuration for the example above could be as follows:
 
                         <!-- corresponds second path unit in diagram: my-category -->
                         <path-unit name="category_path">
-                            <provider name="content_object">
-                                <option name="method" value="getCategory" />
+                            <provider name="content_method">
+                                <option name="method" value="getCategoryName" />
                             </provider>
                             <exists-action strategy="use" />
                             <not-exists-action strategy="throw_exception" />
@@ -183,8 +183,8 @@ The configuration for the example above could be as follows:
 
                         // corresponds second path unit in diagram: my-category
                         'category_path' => array(
-                            'provider' => array('content_object', array(
-                                'method' => 'getCategory',
+                            'provider' => array('content_method', array(
+                                'method' => 'getCategoryName',
                             )),
                             'exists_action' => 'use',
                             'not_exists_action' => 'throw_exception',
@@ -216,9 +216,9 @@ follows::
         /**
          * Returns the category object associated with the topic.
          */
-        public function getCategory()
+        public function getCategoryName()
         {
-            return $this->category;
+            return $this->category->getName();
         }
 
         public function getPublishedDate()

--- a/bundles/routing_auto/providers.rst
+++ b/bundles/routing_auto/providers.rst
@@ -47,47 +47,6 @@ Options
     builder unit is the first content path chain it is understood that it is
     the base of an absolute path.
 
-content_object (base provider)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The content object provider will try and provide a path from an object
-implementing ``RouteReferrersInterface`` provided by a designated method on the
-content document. For example, if you have a ``Topic`` class, which has a
-``getCategory`` method, using this provider you can tell the ``Topic`` auto route
-to use the route of the category as a base.
-
-So basically, if your category document has a path of ``/this/is/my/category``,
-you can use this path as the base of your ``Category`` auto-route.
-
-Options
-.......
-
- - ``method``: **required** Method used to return the document whose route path you wish to use.
-
-.. configuration-block::
-
-    .. code-block:: yaml
-
-        provider: [content_object, { method: getCategory }]
-
-    .. code-block:: xml
-
-        <provider name="content_object">
-            <option name="method" value="getCategory" />
-        </provider>
-
-    .. code-block:: php
-
-        array(
-            // ...
-            'provider' => array('content_object', array('method' => 'getCategory')),
-        );
-
-.. note::
-
-    At the time of writing translated objects are not supported. But a patch
-    is already created for this feature.
-
 content_method
 ~~~~~~~~~~~~~~
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all (or 2.3+) |
| Fixed tickets |  |

Removes references to the ContentObject pending the acceptance of https://github.com/symfony-cmf/RoutingAutoBundle/pull/70
