### PR TITLE
Update the_model.rst

### DIFF
--- a/quick_tour/the_model.rst
+++ b/quick_tour/the_model.rst
@@ -92,9 +92,17 @@ by creating a new class in the AcmeMainBundle::
 
     use Doctrine\Common\Persistence\ObjectManager;
     use Doctrine\Common\DataFixtures\FixtureInterface;
+    use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 
-    class LoadPageData implements FixtureInterface
+    class LoadPageData implements FixtureInterface, OrderedFixtureInterface
     {
+        public function getOrder()
+        {
+            // refers to the order in which the class' load function is called 
+            // (lower return values are called first)
+            return 10;
+        }
+    
         public function load(ObjectManager $documentManager)
         {
         }


### PR DESCRIPTION
When installing via composer as per the documentation, the example does not work with phpcr-odm 1.0. It is necessary to add use Doctrine\Common\DataFixtures\OrderedFixtureInterface;, implement both the FixtureInterface and OrderedFixtureInterface classes and specify a getOrder function with a value larger than that in LoadSimpleCmsData.php, otherwise the following error message is thrown when running php app/console running doctrine:phpcr:fixtures:load:

Property "parent" mapped as ParentDocument may not be empty in document of
class "Symfony\Cmf\Bundle\SimpleCmsBundle\Doctrine\Phpcr\Page"
