### PR TITLE
Update getting-started.rst

### DIFF
--- a/cookbook/creating_a_cms/getting-started.rst
+++ b/cookbook/creating_a_cms/getting-started.rst
@@ -262,6 +262,7 @@ configuration:
             acme.basic_cms.phpcr.initializer:
                 class: Doctrine\Bundle\PHPCRBundle\Initializer\GenericInitializer
                 arguments: 
+                    - 'cms reserved routes'
                     - ["/cms/pages", "/cms/posts", "/cms/routes"]
                 tags:
                     - { name: doctrine_phpcr.initializer }


### PR DESCRIPTION
Doctrine\Bundle\PHPCRBundle\Initializer\GenericInitializer has two required parameters.
What do you think ?
