### PR TITLE
Fixed mismatching namespace

### DIFF
--- a/book/static_content.rst
+++ b/book/static_content.rst
@@ -50,7 +50,7 @@ It also specifies the translation strategy:
         use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCR;
 
         /**
-         * @PHPCRODM\Document(translator="child", referenceable=true)
+         * @PHPCR\Document(translator="child", referenceable=true)
          */
 
 For information on the available translation strategies, refer to the Doctrine


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 1.1 |
| Fixed tickets | no |

PHPCRODM -> PHPCR (to match given namespace)
