### PR TITLE
Fixed link to the symfony-cmf-website repository

### DIFF
--- a/bundles/simple_cms/introduction.rst
+++ b/bundles/simple_cms/introduction.rst
@@ -40,5 +40,5 @@ Sections
 * :doc:`extending_page_class`
 
 .. _`Symfony CMF Standard Edition`: https://github.com/symfony-cmf/symfony-cmf-standard
-.. _`CMF website`: https://github.com/symfony-cmf/cmf-website/
+.. _`CMF website`: https://github.com/symfony-cmf/symfony-cmf-website/
 .. _`Packagist`: https://packagist.org/packages/symfony-cmf/simple-cms-bundle


### PR DESCRIPTION
Fixed link to the symfony-cmf-website repository which is https://github.com/symfony-cmf/symfony-cmf-website instead of https://github.com/symfony-cmf/cmf-website.
