### PR TITLE
Cleanup phpcrodm annotation

### DIFF
--- a/book/database_layer.rst
+++ b/book/database_layer.rst
@@ -101,30 +101,30 @@ class via annotations:
         // src/Acme/TaskBundle/Document/Task.php
         namespace Acme\TaskBundle\Document;
 
-        use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;
+        use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCR;
 
         /**
-         * @PHPCRODM\Document()
+         * @PHPCR\Document()
          */
         class Task
         {
             /**
-             * @PHPCRODM\Id()
+             * @PHPCR\Id()
              */
             protected $id;
 
             /**
-             * @PHPCRODM\String()
+             * @PHPCR\String()
              */
             protected $description;
 
             /**
-             * @PHPCRODM\Boolean()
+             * @PHPCR\Boolean()
              */
             protected $done = false;
 
             /**
-             * @PHPCRODM\ParentDocument()
+             * @PHPCR\ParentDocument()
              */
             protected $parentDocument;
         }
@@ -185,10 +185,10 @@ After this, you have to create getters and setters for the properties.
 
     You can also check out Doctrine's `Basic Mapping Documentation`_ for all
     details about mapping information. If you use annotations, you'll need to
-    prepend all annotations with ``@PHPCRODM\``, which is the name of the imported
-    namespace (e.g. ``@PHPCRODM\Document(..)``), this is not shown in Doctrine's
+    prepend all annotations with ``@PHPCR\``, which is the name of the imported
+    namespace (e.g. ``@PHPCR\Document(..)``), this is not shown in Doctrine's
     documentation. You'll also need to include the
-    ``use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCRODM;`` statement to
+    ``use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCR;`` statement to
     import the PHPCR annotations prefix.
 
 Persisting Documents to PHPCR

--- a/book/structuring_content.rst
+++ b/book/structuring_content.rst
@@ -168,7 +168,7 @@ translations:
     .. code-block:: php-annotations
 
         /**
-         * @PHPCRODM\Document(translator="attribute")
+         * @PHPCR\Document(translator="attribute")
          */
 
 For information on the available translation strategies, refer to the Doctrine

--- a/bundles/block/create_your_own_blocks.rst
+++ b/bundles/block/create_your_own_blocks.rst
@@ -36,6 +36,7 @@ for instance ``acme_main.block.rss``::
     namespace Acme\MainBundle\Document;
 
     use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCR;
+
     use Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\AbstractBlock;
 
     /**

--- a/bundles/menu/menu_factory.rst
+++ b/bundles/menu/menu_factory.rst
@@ -160,7 +160,7 @@ The service needs to be tagged as event listener:
             acme_demo.listener.menu_referrer_listener:
                 class: Acme\DemoBundle\EventListener\CreateMenuItemFromNodeListener
                 arguments:
-                    - @knp_menu.menu_provider
+                    - "@knp_menu.menu_provider"
                 tags:
                     -
                         name: kernel.event_listener

--- a/bundles/phpcr_odm/multilang.rst
+++ b/bundles/phpcr_odm/multilang.rst
@@ -117,25 +117,25 @@ depending on the locale.
         {
             /**
              * The language this document currently is in
-             * @Locale
+             * @PHPCR\Locale
              */
             private $locale;
 
             /**
              * Untranslated property
-             * @Date
+             * @PHPCR\Date
              */
             private $publishDate;
 
             /**
              * Translated property
-             * @String(translated=true)
+             * @PHPCR\String(translated=true)
              */
             private $topic;
 
             /**
              * Language specific image
-             * @Binary(translated=true)
+             * @PHPCR\Binary(translated=true)
              */
             private $image;
         }

--- a/cookbook/creating_a_cms/getting-started.rst
+++ b/cookbook/creating_a_cms/getting-started.rst
@@ -102,6 +102,8 @@ to reduce code duplication::
     // src/Acme/BasicCmsBundle/Document/ContentTrait.php
     namespace Acme\BasicCmsBundle\Document;
 
+    use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCR;
+
     trait ContentTrait
     {
         /**
@@ -185,8 +187,9 @@ The ``Page`` class is therefore nice and simple::
     // src/Acme/BasicCmsBundle/Document/Page.php
     namespace Acme\BasicCmsBundle\Document;
 
-    use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCR;
     use Symfony\Cmf\Component\Routing\RouteReferrersReadInterface;
+
+    use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCR;
 
     /**
      * @PHPCR\Document(referenceable=true)

--- a/cookbook/creating_a_cms/the-frontend.rst
+++ b/cookbook/creating_a_cms/the-frontend.rst
@@ -50,6 +50,8 @@ KnpMenuBundle::
     // ...
     use Knp\Menu\NodeInterface;
 
+    use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCR;
+
     class Page implements RouteReferrersReadInterface, NodeInterface
     {
         // ...

--- a/cookbook/handling_multilang_documents.rst
+++ b/cookbook/handling_multilang_documents.rst
@@ -59,14 +59,18 @@ always happens on a document level, not on the individual translatable fields.
 
     <?php
 
+    // src/Acme/DemoBundle/Document/MyPersistentClass.php
+
+    use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCR;
+
     /**
-     * @PHPCRODM\Document(translator="attribute")
+     * @PHPCR\Document(translator="attribute")
      */
     class MyPersistentClass
     {
         /**
          * Translated property
-         * @String(translated=true)
+         * @PHPCR\String(translated=true)
          */
         private $topic;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | yes |
| Applies to | 1.1+ of the doc (to also catch the new doc) |
| Fixed tickets | - |

clean up all doctrine annotations to follow the format we agreed on.
