### PR TITLE
[WCM] Update docs to use get/setParentDocument instead of get/setParent.

### DIFF
--- a/bundles/menu/introduction.rst
+++ b/bundles/menu/introduction.rst
@@ -54,14 +54,14 @@ each of which specifies a URI::
     $menu = new Menu();
     $menu->setName('main-menu');
     $menu->setLabel('Main Menu');
-    $menu->setParent($menuParent);
+    $menu->setParentDocument($menuParent);
 
     $manager->persist($menu);
 
     $home = new MenuNode();
     $home->setName('home');
     $home->setLabel('Home');
-    $home->setParent($menu);
+    $home->setParentDocument($menu);
     $home->setUri('http://www.example.com/home');
 
     $manager->persist($home);
@@ -69,7 +69,7 @@ each of which specifies a URI::
     $contact = new MenuNode();
     $contact->setName('contact');
     $contact->setLabel('Contact');
-    $contact->setParent($menu);
+    $contact->setParentDocument($menu);
     $contact->setUri('http://www.example.com/contact');
 
     $manager->persist($contact);

--- a/bundles/menu/menu_documents.rst
+++ b/bundles/menu/menu_documents.rst
@@ -18,13 +18,13 @@ the KnpMenu component documentation for more information.
 
 .. code-block:: php
 
-    use Symfony\Cmf\Bundle\MenuBundle\Doctrine\Phpcr\MenuNodeBase;
+    use Symfony\Cmf\Bundle\MenuBundle\Doctrine\Phpcr\MenuNode;
 
     $parent = ...;
 
     // ODM specific
-    $node = new MenuNodeBase();
-    $node->setParent($parent);
+    $node = new MenuNode();
+    $node->setParentDocument($parent);
     $node->setName('home');
 
     // Attributes are the HTML attributes of the DOM element representing the


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | yes (symfony-cmf/MenuBundle 1.1) |
| Applies to | symfony-cmf/MenuBundle 1.1+ |
