### PR TITLE
cleanup menu parent documentation

### DIFF
--- a/bundles/menu/menu_documents.rst
+++ b/bundles/menu/menu_documents.rst
@@ -7,7 +7,8 @@ Menu Documents
 In accordance with the
 :ref:`CMF bundle standards <contrib_bundles_baseandstandardimplementations>`
 you are provided with two menu node implementations, a base document and a
-standard document.
+standard document. Both exist in the ``Model`` namespace as storage agnostic
+classes and in ``Doctrine\Phpcr`` with specific features for PHPCR-ODM.
 
 Base Menu Node
 --------------
@@ -20,11 +21,11 @@ the KnpMenu component documentation for more information.
 
     use Symfony\Cmf\Bundle\MenuBundle\Doctrine\Phpcr\MenuNodeBase;
 
-    $parent = ...;
+    // find the menu tree root
+    $mainMenu = $dm->find('Symfony\Cmf\Bundle\MenuBundle\Doctrine\Phpcr\Menu', '/cms/menu/main');
 
-    // ODM specific
     $node = new MenuNodeBase();
-    $node->setParentDocument($parent);
+    $mainMenu->addChild($node);
     $node->setName('home');
 
     // Attributes are the HTML attributes of the DOM element representing the
@@ -63,6 +64,7 @@ The Standard Menu Node
 The standard menu node supports the following CMF specific features
 out-of-the-box:
 
+* Methods to set and get parent document;
 * Content association;
 * Link type specification (URI, route or content);
 * Standard :doc:`publish workflow <../core/publish_workflow>` integration;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | yes (symfony-cmf/MenuBundle 1.1) |
| Applies to | symfony-cmf/MenuBundle 1.1+ |
| Fixes | #491 is replaced by this |
