### PR TITLE
Update cmf_sandbox.rst

### DIFF
--- a/cookbook/editions/cmf_sandbox.rst
+++ b/cookbook/editions/cmf_sandbox.rst
@@ -121,6 +121,12 @@ run:
 If you don't have sqlite, you can specify ``pdo_mysql`` or ``pdo_pgsql`` and
 provide the database name and login credentials to use.
 
+Then you have to set up your database with:
+
+.. code-block:: bash
+
+    $ php app/console doctrine:phpcr:init:dbal
+
 Once your database is set up, you need to `register the node types`_ for
 phpcr-odm:
 


### PR DESCRIPTION
Adding "php app/console doctrine:phpcr:init:dbal" to setup the database using pdo_mysql otherwise I have this error:

An exception occurred while executing 'SELECT \* FROM phpcr_namespaces':
SQLSTATE[42S02]: Base table or view not found: 1146 Table 'cmf.phpcr_namespaces' doesn't exist
Executing initializer: CmfRoutingBundle
