### PR TITLE
Typo fixes for DocumentManager arguments

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -457,7 +457,7 @@ follows::
         /**
          * @param DocumentManager $dm
          */
-        public function load(ObjectManager $dm)
+        public function load(DocumentManager $dm)
         {
             $route = new Route();
             $route->setParentDocument($dm->find(null, '/cms/routes'));

--- a/book/simplecms.rst
+++ b/book/simplecms.rst
@@ -57,7 +57,7 @@ To create a page, use the
         /**
          * @param DocumentManager $dm
          */
-        public function load(ObjectManager $dm)
+        public function load(DocumentManager $dm)
         {
             $parent = $dm->find(null, '/cms/simple');
             $page = new Page();
@@ -105,7 +105,7 @@ structure, you would do::
         /**
          * @param DocumentManager $dm
          */
-        public function load(ObjectManager $dm)
+        public function load(DocumentManager $dm)
         {
             $root = $dm->find(null, '/cms/simple');
 

--- a/cookbook/creating_a_cms/the-frontend.rst
+++ b/cookbook/creating_a_cms/the-frontend.rst
@@ -121,7 +121,7 @@ to which you will add the existing ``Home`` page and an additional ``About`` pag
     // ...
     class LoadPageData implements FixtureInterface
     {
-        public function load(ObjectManager $dm)
+        public function load(DocumentManager $dm)
         {
             // ...
             $rootPage = new Page();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | 1.1 (at least) |
| Fixed tickets | https://github.com/symfony-cmf/standard-edition/issues/13 (partly) |

Documentation-only fixes of 3 specific cases where I found the import to be correct, and only the type hint wrong.

I'm happy to extend it to include more cases, so feedback is welcome about the specific way it needs to be done for each case (see [original issue](https://github.com/symfony-cmf/standard-edition/issues/13) for more information).
