### PR TITLE
Updated extensions for Python3

### DIFF
--- a/_exts/sensio/sphinx/configurationblock.py
+++ b/_exts/sensio/sphinx/configurationblock.py
@@ -6,7 +6,6 @@
 
 from docutils.parsers.rst import Directive, directives
 from docutils import nodes
-from string import upper
 
 class configurationblock(nodes.General, nodes.Element):
     pass

--- a/_exts/sensio/sphinx/phpcode.py
+++ b/_exts/sensio/sphinx/phpcode.py
@@ -7,7 +7,6 @@
 from docutils import nodes, utils
 
 from sphinx.util.nodes import split_explicit_title
-from string import lower
 
 def php_namespace_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
     text = utils.unescape(text)
@@ -82,7 +81,7 @@ def php_phpclass_role(typ, rawtext, text, lineno, inliner, options={}, content=[
     text = utils.unescape(text)
     has_explicit_title, title, full_class = split_explicit_title(text)
 
-    full_url = 'http://php.net/manual/en/class.%s.php' % lower(full_class)
+    full_url = 'http://php.net/manual/en/class.%s.php' % full_class.lower()
 
     if not has_explicit_title:
         title = full_class
@@ -94,7 +93,7 @@ def php_phpfunction_role(typ, rawtext, text, lineno, inliner, options={}, conten
     text = utils.unescape(text)
     has_explicit_title, title, full_function = split_explicit_title(text)
 
-    full_url = 'http://php.net/manual/en/function.%s.php' % lower(full_function.replace('_', '-'))
+    full_url = 'http://php.net/manual/en/function.%s.php' % full_function.replace('_', '-').lower()
 
     if not has_explicit_title:
         title = full_function


### PR DESCRIPTION
The functions lower() and upper() are deprected and seem to be removed in Python 3.7

https://docs.python.org/2/library/string.html#string.lower

Is there a reason we don't the sensio symfony extension as a git submodule?
