### PR TITLE
Update auto-routing.rst

### DIFF
--- a/tutorial/auto-routing.rst
+++ b/tutorial/auto-routing.rst
@@ -132,6 +132,7 @@ First you need to configure the auto routing bundle:
             persistence:
                 phpcr:
                     enabled: true
+                    route_basepath: /cms/routes
 
     .. code-block:: xml
 
@@ -139,7 +140,7 @@ First you need to configure the auto routing bundle:
         <container xmlns="http://symfony.com/schema/dic/services">
             <config xmlns="http://cmf.symfony.com/schema/dic/routing_auto">
                 <persistence>
-                    <phpcr />
+                    <phpcr route-basepath="/cms/routes" />
                 </persistence>
             </config>
        </container>
@@ -151,6 +152,7 @@ First you need to configure the auto routing bundle:
             'persistence' => array(
                 'phpcr' => array(
                     'enabled' => true,
+                    'route_basepath' => '/cms/routes',
                 ),
             ),
         ));


### PR DESCRIPTION
It appears that in RC1 of auto-routing-bundle the routes fail to generate unless the route basepath is set in the config.

Exception:
[Doctrine\ODM\PHPCR\Id\IdException]
Property "parent" mapped as ParentDocument may not be empty in document of class "Symfony\Cmf\Bundle\RoutingAutoBundle\Model\AutoRoute"

Simply adding the route basepath fixes this issue.

| Q | A |
| --- | --- |
| Doc fix? | Yes |
| New docs? | No |
| Applies to | auto-routing-bundle RC1 |
| Fixed tickets | #555 |
