### PR TITLE
Various fixes for tutorial

### DIFF
--- a/tutorial/content-to-controllers.rst
+++ b/tutorial/content-to-controllers.rst
@@ -108,7 +108,7 @@ object and all the ``Posts`` to the view::
          */
         public function pageAction($contentDocument)
         {
-            $dm = $this->get('doctrine_phpcr')->getManagerForClass('AcmeBasicCmsBundle:Post');
+            $dm = $this->get('doctrine_phpcr')->getManager();
             $posts = $dm->getRepository('AcmeBasicCmsBundle:Post')->findAll();
 
             return array(
@@ -154,6 +154,10 @@ Add a corresponding Twig template (note that this works because you use the
         </ul>
 
 Now have another look at: http://localhost:8000/page/home
+
+.. note::
+
+    If you get an error, try clearing the cache.
 
 Notice what is happening with the post object and the ``path`` function  - you
 pass the ``Post`` object and the ``path`` function will pass the object to the

--- a/tutorial/the-frontend.rst
+++ b/tutorial/the-frontend.rst
@@ -114,7 +114,8 @@ to which you will add the existing ``Home`` page and an additional ``About`` pag
     {
         public function load(ObjectManager $dm)
         {
-            // ...
+            $parent = $dm->find(null, '/cms/pages');
+
             $rootPage = new Page();
             $rootPage->setTitle('main');
             $rootPage->setParentDocument($parent);


### PR DESCRIPTION
Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\Route::setRouteContent() not defined, use setContent() instead
For Symfony\Cmf\Bundle\ContentBundle\Doctrine\Phpcr\StaticContent, title and body are not nullable
