### PR TITLE
Generate with no interaction -> xml

### DIFF
--- a/tutorial/getting-started.rst
+++ b/tutorial/getting-started.rst
@@ -93,7 +93,7 @@ Now you can generate the bundle in which you will write most of your code:
 
 .. code-block:: bash
 
-    $ php app/console generate:bundle --namespace=Acme/BasicCmsBundle --dir=src --no-interaction
+    $ php app/console generate:bundle --namespace=Acme/BasicCmsBundle --dir=src
 
 The Documents
 .............


### PR DESCRIPTION
This is a small issue, almost nagging
When you generate the bundle without interaction, the services and routing files in the bundle are in xml format.
Strange because the YAML version is always first in the row. Confusing.
I don't think there is an option to specify YAML format, is it?
So I went for generating the bundle with interaction