### PR TITLE
Use statement Template

### DIFF
--- a/tutorial/content-to-controllers.rst
+++ b/tutorial/content-to-controllers.rst
@@ -15,7 +15,7 @@ Map the ``$routes`` property to contain a collection of all the routes which ref
 document::
 
     // src/AcmeBundle/BasicCmsBundle/Document/ContentTrait.php
-    
+
     // ...
     trait ContentTrait
     {


### PR DESCRIPTION
[Semantical Error] The annotation "@Template" in method Acme\BasicCmsBundle\Controller\DefaultController::pageAction() was never imported. Did you maybe forget to add a "use" statement for this annotation?
Yes we did :-)

Also, running http://localhost:8000/page/home for the first time didn't work. I got an error about routes and the /Document/Page
The error was on line 6 on the page.html.twig file, without {{ path( post) }} it worked. Very strange, suddenly it worked. Some caching stuff?
(sorry, I don't have the exact error message, I can't reproduce it anymore)
