### PR TITLE
services instead of config

### DIFF
--- a/tutorial/the-frontend.rst
+++ b/tutorial/the-frontend.rst
@@ -158,7 +158,7 @@ configuration:
 
     .. code-block:: yaml
 
-        # src/Acme/BasicCmsBundle/Resources/config/config.yml
+        # src/Acme/BasicCmsBundle/Resources/config/services.yml
         services:
             acme.basic_cms.menu_provider:
                 class: Symfony\Cmf\Bundle\MenuBundle\Provider\PhpcrMenuProvider
@@ -204,7 +204,7 @@ configuration:
 
     .. code-block:: php
 
-        // src/Acme/BasicCmsBundle/Resources/config/config.php
+        // src/Acme/BasicCmsBundle/Resources/config/services.php
         use Symfony\Component\DependencyInjection\Reference;
         // ...
 


### PR DESCRIPTION
The menu provider should be registered in the services, not in the config, right?
