### PR TITLE
[routing-auto-bundle] Fix indentation typo in routing auto bundle yaml configuration example

### DIFF
--- a/bundles/routing_auto/introduction.rst
+++ b/bundles/routing_auto/introduction.rst
@@ -100,8 +100,8 @@ document could be defined as follows:
         Acme\ForumBundle\Document\Topic:
             uri_schema: /my-forum/{category}/{title}
             token_providers:
-            category: [content_method, { method: getCategoryTitle, slugify: true }]
-            title: [content_method, { method: getTitle }] # slugify is true by default
+                category: [content_method, { method: getCategoryTitle, slugify: true }]
+                title: [content_method, { method: getTitle }] # slugify is true by default
 
     .. code-block:: xml
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all (or 2.3+) |
| Fixed tickets | no |
