### PR TITLE
Use Route annotations

### DIFF
--- a/tutorial/make-homepage.rst
+++ b/tutorial/make-homepage.rst
@@ -330,6 +330,7 @@ the page action::
 
     // ...
     use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+
     class DefaultController extends Controller
     {
         // ...


### PR DESCRIPTION
Without the use statement, this din't worked

Also I had to set the routing.yml from the bundle to::
    AcmeBasicCmsBundle:
      resource: "@AcmeBasicCmsBundle/Controller"
      type: annotation
