### PR TITLE
Update create_new_project_phpcr_odm.rst

### DIFF
--- a/cookbook/database/create_new_project_phpcr_odm.rst
+++ b/cookbook/database/create_new_project_phpcr_odm.rst
@@ -36,7 +36,7 @@ content repository.
         ...
         "require": {
             ...
-            "doctrine/phpcr-bundle": "1.0.0",
+            "doctrine/phpcr-bundle": "1.1.*",
             "doctrine/phpcr-odm": "1.0.*",
             "jackalope/jackalope-doctrine-dbal": "1.0.0"
         }


### PR DESCRIPTION
Tutorial was using older version (1.0.0) of doctrine/phpcr-bundle now using `1.1.*`
