### PR TITLE
fixed wrong prefix for publish workflow configuration

### DIFF
--- a/bundles/menu/configuration.rst
+++ b/bundles/menu/configuration.rst
@@ -270,7 +270,7 @@ To disable the menu content voter, use:
 
     .. code-block:: yaml
 
-        cmf_menu:
+        cmf_core:
             publish_workflow:
                 enabled: false
 
@@ -279,7 +279,7 @@ To disable the menu content voter, use:
         <?xml version="1.0" charset="UTF-8" ?>
         <container xmlns="http://symfony.com/schema/dic/services">
 
-            <config xmlns="http://cmf.symfony.com/schema/dic/menu">
+            <config xmlns="http://cmf.symfony.com/schema/dic/core">
                 <publish-workflow
                     enabled="false"
                 />
@@ -288,7 +288,7 @@ To disable the menu content voter, use:
 
     .. code-block:: php
 
-        $container->loadFromExtension('cmf_menu', array(
+        $container->loadFromExtension('cmf_core', array(
             'publish_workflow' => array(
                 'enabled' => false,
             ),


### PR DESCRIPTION
Just wanted to disable the `PublishableVoter`, and found out that the wrong configuration prefix was shown in the docs.
