### PR TITLE
Fixes route demo in Router documentation

### DIFF
--- a/quick_tour/the_router.rst
+++ b/quick_tour/the_router.rst
@@ -47,7 +47,7 @@ other examples:
             /about       # /about Route
             /contact     # /contact Route
                 /team    # /contact/team Route
-                /docs    # /docs Route
+                /docs    # /contact/docs Route
 
 OK, you got it? The only thing the Router has to do is prefix the route with a
 specific path prefix and load that document. In the case of the SimpleCmsBundle,


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets |  |

It looks like the `/docs` route is supposed to be nested under the `/contact` route but the comment didn't reflect this.
