### PR TITLE
add missing use statements to fixture examples

### DIFF
--- a/book/simplecms.rst
+++ b/book/simplecms.rst
@@ -49,8 +49,10 @@ To create a page, use the
     // // src/Acme/MainBundle/DataFixtures/PHPCR/LoadSimpleCms.php
     namespace Acme\DemoBundle\DataFixtures\PHPCR;
 
-    use Symfony\Cmf\Bundle\SimpleCmsBundle\Doctrine\Phpcr\Page;
+    use Doctrine\Common\DataFixtures\FixtureInterface;
+    use Doctrine\Common\Persistence\ObjectManager;
     use Doctrine\ODM\PHPCR\DocumentManager;
+    use Symfony\Cmf\Bundle\SimpleCmsBundle\Doctrine\Phpcr\Page;
 
     class LoadSimpleCms implements FixtureInterface
     {
@@ -97,8 +99,10 @@ structure, you would do::
     // // src/Acme/MainBundle/DataFixtures/PHPCR/LoadSimpleCms.php
     namespace Acme\DemoBundle\DataFixtures\PHPCR;
 
-    use Symfony\Cmf\Bundle\SimpleCmsBundle\Doctrine\Phpcr\Page;
+    use Doctrine\Common\DataFixtures\FixtureInterface;
+    use Doctrine\Common\Persistence\ObjectManager;
     use Doctrine\ODM\PHPCR\DocumentManager;
+    use Symfony\Cmf\Bundle\SimpleCmsBundle\Doctrine\Phpcr\Page;
 
     class LoadSimpleCms implements FixtureInterface
     {

--- a/tutorial/the-frontend.rst
+++ b/tutorial/the-frontend.rst
@@ -108,8 +108,13 @@ first level of child items. Modify your fixtures to declare a root element
 to which you will add the existing ``Home`` page and an additional ``About`` page::
 
     // src/Acme/BasicCmsBundle/DataFixtures/Phpcr/LoadPageData.php
+    namespace Acme\DemoBundle\DataFixtures\PHPCR;
 
-    // ...
+    use Doctrine\Common\DataFixtures\FixtureInterface;
+    use Doctrine\Common\Persistence\ObjectManager;
+    use Doctrine\ODM\PHPCR\DocumentManager;
+    use Symfony\Cmf\Bundle\SimpleCmsBundle\Doctrine\Phpcr\Page;
+
     class LoadPageData implements FixtureInterface
     {
         public function load(ObjectManager $dm)


### PR DESCRIPTION
fix #506
