### PR TITLE
as the initializer is only run when sonata is present, ensure users create /cms/routes themselves

### DIFF
--- a/book/routing.rst
+++ b/book/routing.rst
@@ -498,9 +498,10 @@ also ``/projects`` as there is a default for the id parameter.
 
     As you can see, the code explicitely creates the ``/cms/routes`` path.
     The RoutingBundle only creates this path automatically if the Sonata Admin
-    was enabled in the routign configuration. Otherwise, it'll assume you
-    do something yourself to create the path (by configuring an initializer
-    or doing it in a fixture like this).
+    was enabled in the routing configuration using an :ref:`initializer
+    <phpcr-odm-repository-initializers>`. Otherwise, it'll assume you do
+    something yourself to create the path (by configuring an initializer or
+    doing it in a fixture like this).
 
 Because you defined the ``{id}`` route parameter, your controller can expect an
 ``$id`` parameter. Additionally, because you called setRouteContent on the

--- a/bundles/routing/configuration.rst
+++ b/bundles/routing/configuration.rst
@@ -443,9 +443,10 @@ initializer when you create your nodes your self (e.g. using Alice_).
 
 .. caution::
 
-    The initializer is only run when the sonata admin is enabled. When you
-    don't enable the sonata admin, it is assumed that you created an initializer
-    yourself.
+    Initializers are forced to be disabled when Sonata Admin is not enabled.
+    In such cases, you might have multiple route basepaths which are created
+    by other sources. If the route basepath isn't created by another source,
+    you have to configure an :ref:`initializer <phpcr-odm-repository-initializers>`.
 
 orm
 """


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Applies to | all |
| Fixed tickets | https://github.com/symfony-cmf/standard-edition/issues/23 |
