### PR TITLE
Fixed configuration example for defunct redirect

### DIFF
--- a/bundles/routing_auto/defunct_route_handlers.rst
+++ b/bundles/routing_auto/defunct_route_handlers.rst
@@ -62,8 +62,12 @@ path.
             </mapping>
         </auto-mapping>
 
-For the redirect to work you will also need to configure a redirect controller
-in the ``cmf_routing`` configuration:
+For the redirect to take place you will need to tell the ``DynamicRouter`` to
+route routes with the type ``cmf_routing_auto.redirect`` to a controller which
+can perform the redirect.
+
+The RoutingAutoBundle has included such a controller for your convenience. It
+can be configured as follows:
 
 .. configuration-block::
 
@@ -73,7 +77,9 @@ in the ``cmf_routing`` configuration:
         cmf_routing:
             dynamic:
                 controllers_by_class:
-                    Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\RedirectRoute: cmf_routing.redirect_controller:redirectAction
+                    # ...
+                controllers_by_type:
+                    cmf_routing_auto.redirect: cmf_routing_auto.redirect_controller:redirectAction
 
     .. code-block:: xml
 
@@ -83,9 +89,9 @@ in the ``cmf_routing`` configuration:
 
             <config xmlns="http://cmf.symfony.com/schema/dic/routing">
                 <dynamic>
-                    <controller-by-class
-                        class="Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\RedirectRoute">
-                        cmf_routing.redirect_controller:redirectAction
+                    <controller-by-type
+                        type="cmf_routing_auto.redirect">
+                        cmf_routing_auto.redirect_controller:redirectAction
                     </controller-by-class>
                 </dynamic>
             </config>
@@ -97,8 +103,8 @@ in the ``cmf_routing`` configuration:
         // app/config/config.php
         $container->loadFromExtension('cmf_routing', array(
             'dynamic' => array(
-                'controllers_by_class' => array(
-                    'Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\RedirectRoute' => 'cmf_routing.redirect_controller:redirectAction',
+                'controllers_by_type' => array(
+                    'cmf_routing_auto.redirect' => 'cmf_routing_auto.redirect_controller:redirectAction'
                 ),
             ),
         ));


### PR DESCRIPTION
RoutingAuto defunct redirect configuration example uses class instead of type

| Q             | A
| ------------- | ---
| Doc fix?      | yes
| New docs?     | no
| Applies to    | 1.0
| Fixed tickets | n/a

## Depends

- https://github.com/symfony-cmf/RoutingAutoBundle/pull/146