### PR TITLE
cleanup installation instructions

### DIFF
--- a/book/installation.rst
+++ b/book/installation.rst
@@ -96,9 +96,17 @@ dependencies, use the ``install`` command:
 
     $ composer install
 
+To try out things, you can accept the default values for all questions you are
+asked about the parameters.yml. Revisit that file later when you know more
+about Jackalope.
+
+Setup
+-----
+
+You are almost there. A few more steps need to be done to be ready.
 
 Set up the Database
--------------------
+~~~~~~~~~~~~~~~~~~~
 
 The next step is to set up the database. If you want to use SQLite as your
 database backend just go ahead and run the following:
@@ -115,7 +123,20 @@ folder, containing the database content. The two commands after it will setup
 PHPCR and the final command will load some fixtures, so you can access the
 Standard Edition using a web server.
 
-The project should now be accessible on your web server. If you have PHP 5.4
+Preparing Assetic
+~~~~~~~~~~~~~~~~~
+
+To use the frontend editing in ``prod`` environment, you need to tell Assetic
+to dump the assets to the filesystem:
+
+.. code-block:: bash
+
+    $ php app/console --env=prod assetic:dump
+
+Configure a Webserver
+~~~~~~~~~~~~~~~~~~~~~
+
+The project is now ready to be served by your web server. If you have PHP 5.4
 installed you can alternatively use the PHP internal web server:
 
 .. code-block:: bash
@@ -127,7 +148,6 @@ And then access the CMF via:
 .. code-block:: text
 
     http://localhost:8000
-
 
 If you run an Apache installation as described in the `Symfony cookbook article on setup`_,
 your URL will look like this:

--- a/bundles/block/create_your_own_blocks.rst
+++ b/bundles/block/create_your_own_blocks.rst
@@ -136,7 +136,7 @@ that knows how to fetch the feed data of an ``RssBlock``::
         public function execute(BlockContextInterface $blockContext, Response $response = null)
         {
             $block = $blockContext->getBlock();
-            
+
             if (!$block->getEnabled()) {
                 return new Response();
             }
@@ -291,7 +291,7 @@ on the current page:
 
     This mechanism is not recommended. For optimal load times, it is better
     to have a central assets definition for your project and aggregate them
-    into a single Stylesheet and a single JavaScript file, e.g. with assetic_,
+    into a single Stylesheet and a single JavaScript file, e.g. with Assetic_,
     rather than having individual ``<link>`` and ``<script>`` tags for each
     single file.
 
@@ -341,4 +341,4 @@ handles, as per the ``getType`` method of the block. The second argument is the
             ->addTag('sonata.block')
         ;
 
-.. _assetic: http://symfony.com/doc/current/cookbook/assetic/asset_management.html
+.. _Assetic: http://symfony.com/doc/current/cookbook/assetic/asset_management.html

--- a/bundles/create/developing-hallo.rst
+++ b/bundles/create/developing-hallo.rst
@@ -34,10 +34,10 @@ To use this template, specify ``hallo-coffee`` as editor in the
             ))
         ) ?>
 
-The hallo-coffee template uses assetic to load the coffee script files from
+The hallo-coffee template uses Assetic to load the coffee script files from
 ``Resources/public/vendor/hallo/src``, rather than the precompiled JavaScript
 from ``Resources/public/vendor/create/deps/hallo-min.js``. This also means
-that you need to add a mapping for coffeescript in your assetic configuration
+that you need to add a mapping for coffeescript in your Assetic configuration
 and you need the `coffee compiler set up correctly`_.
 
 .. configuration-block::

--- a/bundles/create/introduction.rst
+++ b/bundles/create/introduction.rst
@@ -194,8 +194,8 @@ You also need to configure the FOSRestBundle to handle json:
         ));
 
 If you want to use Assetic to combine the CSS and JavaScript used for
-create.js, you need to enable the CreateBundle in the assetic configuration.
-Find the configuration for ``assetic.bundles``. If it is not present, assetic
+create.js, you need to enable the CreateBundle in the Assetic configuration.
+Find the configuration for ``assetic.bundles``. If it is not present, Assetic
 automatically scans all bundles for assets and you don't need to do anything.
 If you limit the bundles, you need to add ``CmfCreateBundle`` to the list of
 bundles.
@@ -227,6 +227,14 @@ bundles.
             ),
         ));
 
+If you were not using Assetic previously, you need to call the ``assetic:dump``
+command in your deployment process, or the Javascript and CSS files will not be
+found:
+
+.. code-block:: bash
+
+    $ php app/console --env=prod assetic:dump
+
 Routing
 ~~~~~~~
 
@@ -256,7 +264,7 @@ routing configuration to enable the REST end point for saving content:
         $collection->addCollection($loader->import("@CmfCreateBundle/Resources/config/routing/rest.xml"));
 
         return $collection;
-        
+
 .. tip::
 
     If you don't want these routes to be prefixed by the current locale, you can
@@ -350,7 +358,7 @@ after those to be able to customize as needed) with:
 
 .. caution::
 
-    Make sure assetic is rewriting the paths in your CSS files properly or you
+    Make sure Assetic is rewriting the paths in your CSS files properly or you
     might not see icon images.
 
 In your page bottom area, load the JavaScript files. If you are using Symfony 2.2 or

--- a/cookbook/editions/cmf_sandbox.rst
+++ b/cookbook/editions/cmf_sandbox.rst
@@ -158,7 +158,7 @@ The sandbox should now be accessible on your web server.
     http://localhost/app_dev.php
 
 In order to run the sandbox in production mode you need to generate the
-doctrine proxies and dump the assetic assets:
+doctrine proxies and dump the Assetic assets:
 
 .. code-block:: text
 


### PR DESCRIPTION
we added create to the standard edition but missed to add the assetic:dump instructions.

fix https://github.com/symfony-cmf/CreateBundle/issues/134