### PR TITLE
[WCM] Add CreateBundle chain mapper information

### DIFF
--- a/bundles/create/configuration.rst
+++ b/bundles/create/configuration.rst
@@ -72,16 +72,16 @@ For more information, see the
 You can specify a service implementing ``Midgard\CreatePHP\RdfMapperInterface``
 that will handle objects that need to be stored by the REST handler of
 CreatePHP. You need to either specify this service, enable phpcr or orm
-persistence or provide a ``cmf_create.mapper`` tagged mapper for this
-bundle to work.
+persistence or define one or more services that implement the
+``Midgard\CreatePHP\RdfChainableMapperInterface`` and tag them with ``cmf_create.mapper``.
 
 .. _config-create-persistence:
 
 ``persistence``
 ~~~~~~~~~~~~~~~
 
-This defines the persistence driver and associated classes. The default
-persistence configuration has the following configurations.
+This defines a persistence driver for Doctrine PHPCR-ODM documents or Doctrine ORM entities.
+If you specify neither, see :ref:`config-create-object-mapper-service-id`.
 
 ``phpcr``
 .........
@@ -91,7 +91,6 @@ persistence configuration has the following configurations.
     .. code-block:: yaml
 
         cmf_create:
-            object_mapper_service_id: ~
             persistence:
                 phpcr:
                     enabled:      false
@@ -181,7 +180,6 @@ your content is gone.
     .. code-block:: yaml
 
         cmf_create:
-            object_mapper_service_id: ~
             persistence:
                 orm:
                     enabled:      false

--- a/bundles/create/configuration.rst
+++ b/bundles/create/configuration.rst
@@ -62,13 +62,29 @@ For more information, see the
             ),
         ));
 
+.. _config-create-object-mapper-service-id:
+
+``object_mapper_service_id``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**type**: ``string`` **default**: ``"cmf_create.chain_mapper"``
+
+You can specify a service implementing ``Midgard\CreatePHP\RdfMapperInterface``
+that will handle objects that need to be stored by the REST handler of
+CreatePHP. You need to either specify this service, enable phpcr or orm
+persistence or provide a ``cmf_create.mapper`` tagged mapper for this
+bundle to work.
+
 .. _config-create-persistence:
 
 ``persistence``
 ~~~~~~~~~~~~~~~
 
 This defines the persistence driver and associated classes. The default
-persistence configuration has the following configuration:
+persistence configuration has the following configurations.
+
+``phpcr``
+.........
 
 .. configuration-block::
 
@@ -127,13 +143,6 @@ persistence configuration has the following configuration:
             ),
         ));
 
-``object_mapper_service_id``
-""""""""""""""""""""""""""""
-
-You can specify a service implementing ``Midgard\CreatePHP\RdfMapperInterface``
-that will handle objects that need to be stored by the REST handler of
-CreatePHP. You need to either specify this service or enable the phpcr
-persistence for this bundle to work.
 
 ``enabled``
 """""""""""
@@ -163,6 +172,61 @@ If you need different image handling, you can either overwrite
 Set delete to true to enable the simple delete workflow. This allows to directly
 delete content from the frontend. Be careful, there are no special checks once you confirm deletion
 your content is gone.
+
+``orm``
+.......
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        cmf_create:
+            object_mapper_service_id: ~
+            persistence:
+                orm:
+                    enabled:      false
+                    manager_name: ~
+
+    .. code-block:: xml
+
+        <?xml version="1.0" charset="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services">
+            <config xmlns="http://cmf.symfony.com/schema/dic/create">
+                <persistence>
+                    <orm
+                        enabled="false"
+                        manager-name="null"
+                    />
+                </persistence>
+            </config>
+        </container>
+
+    .. code-block:: php
+
+        $container->loadFromExtension('cmf_create', array(
+            'persistence' => array(
+                'orm' => array(
+                    'enabled'      => false,
+                    'manager_name' => null,
+                ),
+            ),
+        ));
+
+
+``enabled``
+"""""""""""
+
+**type**: ``boolean`` **default**: ``false``
+
+If ``true``, the ORM is included in the chain mapper.
+
+``manager_name``
+""""""""""""""""
+
+**type**: ``string`` **default**: ``null``
+
+The name of the Doctrine Manager to use.
+
 
 Metadata Handling
 ~~~~~~~~~~~~~~~~~
@@ -198,19 +262,19 @@ Metadata Handling
         ));
 
 ``auto_mapping``
-""""""""""""""""
+................
 
 If not set to false, the CreateBundle will look for mapping files in every
 bundle in the directory ``Resources/rdf-mappings``.
 
 ``rdf_config_dirs``
-"""""""""""""""""""
+...................
 
 Additional directories to look for mapping files besides the auto mapped
 directory.
 
 ``map``
-"""""""
+.......
 
 Mapping from RDF type name to class. This configuration is used when adding
 items to collections. *Note that collection support is currently incomplete
@@ -270,26 +334,26 @@ setting is the ``plain_text_types``.
         ));
 
 ``plain_text_types``
-""""""""""""""""""""
+....................
 
 A list of RDFa field types that will be edited with a plain text editor without
 any formatting options. All other fields are edited with the WYSIWYG options
 activated.
 
 ``editor_base_path``
-""""""""""""""""""""
+....................
 
 If you use a non-standard setup, you can adjust the editor base path
 configuration. This is only relevant for CKEditor.
 
 ``fixed_toolbar``
-"""""""""""""""""
+.................
 
 Fix the editor toolbar on top of the page. Currently only supported by the
 hallo.js editor.
 
 ``stanbol_url``
-"""""""""""""""
+...............
 
 Apache stanbol can be used for semantic enhancement of content. This feature
 can optionally be used with the hallo.js editor.

--- a/bundles/create/introduction.rst
+++ b/bundles/create/introduction.rst
@@ -256,7 +256,7 @@ routing configuration to enable the REST end point for saving content:
         $collection->addCollection($loader->import("@CmfCreateBundle/Resources/config/routing/rest.xml"));
 
         return $collection;
-        
+
 .. tip::
 
     If you don't want these routes to be prefixed by the current locale, you can
@@ -515,36 +515,41 @@ domain objects. Data needs to be stored back into the database.
     The chain mapper and ORM configuration was introduced in CreateBundle
     1.3. Prior, only the PHPCR-ODM mapper was available.
 
+Adding Custom Mappers to the Chain
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 The CreateBundle provides a chain mapper service that supports multiple mappers.
 Mappers for Doctrine PHPCR-ODM and Doctrine ORM are provided and can be enabled
 via :ref:`persistence configuration <config-create-persistence>`.
 
-You may provide mappers to the chain mapper in addition to or in place of the
-provided mappers. They must implement ``Midgard\CreatePHP\RdfChainableMapperInterface``
-and be tagged with ``create_cmf.mapper``.
+You may provide mappers to the chain mapper in addition to or in place of
+the provided mappers. They must implement ``Midgard\CreatePHP\RdfChainableMapperInterface``
+and be tagged with ``create_cmf.mapper``. You may provide the tag with an
+alias which will be prepended to subjects, the RDFa about field. If an alias
+is not provided, the service's id will be used instead.
 
 .. configuration-block::
 
     .. code-block:: yaml
 
         services:
-            acme_core.my_mapper:
-                class: "%my_namespace.my_mapper_class%"
+            app.elasticsearch_mapper:
+                class: "AppBundle\Mapper\ElasticSearchMapper"
                 tags:
-                    - { name: create_cmf.mapper, alias: my_mapper_alias }
+                    - { name: create_cmf.mapper, alias: elasticsearch }
 
     .. code-block:: xml
 
-        <service id="acme_core.my_mapper" class="%my_namespace.my_mapper_class%">
-            <tag name="create_cmf.mapper" alias="my_mapper_alias" />
+        <service id="app.elasticsearch_mapper" class="AppBundle\Mapper\ElasticSearchMapper">
+            <tag name="create_cmf.mapper" alias="elasticsearch" />
             <!-- ... -->
         </service>
 
     .. code-block:: php
 
         $container
-            ->register('acme_core.my_mapper', '%my_namespace.my_mapper_class')
-            ->addTag('create_cmf.mapper', array('alias' => 'my_mapper_alias'))
+            ->register('app.elasticsearch_mapper', 'AppBundle\Mapper\ElasticSearchMapper')
+            ->addTag('create_cmf.mapper', array('alias' => 'elasticsearch'))
         ;
 
 You may instead set :ref:`config-create-object-mapper-service-id` and use

--- a/bundles/create/introduction.rst
+++ b/bundles/create/introduction.rst
@@ -511,18 +511,44 @@ Mapping Requests to Domain Objects
 One last piece is the mapping between CreatePHP data and the application
 domain objects. Data needs to be stored back into the database.
 
-Currently, the CreateBundle only provides a service to map to Doctrine
-PHPCR-ODM. If you do not enable the phpcr persistence layer, you need to
-configure the ``cmf_create.object_mapper_service_id``.
+.. versionadded:: 1.3
+    The chain mapper and ORM configuration was introduced in CreateBundle
+    1.3. Prior, only the PHPCR-ODM mapper was available.
 
-.. tip::
+The CreateBundle provides a chain mapper service that supports multiple mappers.
+Mappers for Doctrine PHPCR-ODM and Doctrine ORM are provided and can be enabled
+via :ref:`persistence configuration <config-create-persistence>`.
 
-    Doctrine ORM support is coming soon. There is an open pull request on the
-    CreatePHP library to add such a mapper. This mapper will also be provided
-    as a service by the CreateBundle 1.1.
+You may provide mappers to the chain mapper in addition to or in place of the
+provided mappers. They must implement ``Midgard\CreatePHP\RdfChainableMapperInterface``
+and be tagged with ``create_cmf.mapper``.
 
-CreatePHP would support specific mappers per RDFa type. If you need that, dig
-into the CreatePHP and CreateBundle and do a pull request to enable this feature.
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        services:
+            acme_core.my_mapper:
+                class: "%my_namespace.my_mapper_class%"
+                tags:
+                    - { name: create_cmf.mapper, alias: my_mapper_alias }
+
+    .. code-block:: xml
+
+        <service id="acme_core.my_mapper" class="%my_namespace.my_mapper_class%">
+            <tag name="create_cmf.mapper" alias="my_mapper_alias" />
+            <!-- ... -->
+        </service>
+
+    .. code-block:: php
+
+        $container
+            ->register('acme_core.my_mapper', '%my_namespace.my_mapper_class')
+            ->addTag('create_cmf.mapper', array('alias' => 'my_mapper_alias'))
+        ;
+
+You may instead set :ref:`config-create-object-mapper-service-id` and use
+your own mapper in place of the chain mapper.
 
 Workflows
 ---------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Doc fix?      | no
| New docs?     | yes symfony-cmf/CreateBundle#135
| Applies to    | 1.3
| Fixed tickets | 

Adds documentation about the chain mapper added in the create bundle allowing simultaneous use of PHPCR and ORM.