### PR TITLE
cleaning up seo content_listener documentation

### DIFF
--- a/bundles/seo/configuration.rst
+++ b/bundles/seo/configuration.rst
@@ -100,9 +100,11 @@ content_key
 
 **type**: ``string`` **default**: ``null`` (or ``DynamicRouter::CONTENT_KEY`` when RoutingBundle is enabled)
 
-The name of the Request attribute which contains the content object. This is
-required when the RoutingBundle is not enabled, otherwise it defaults to
-``DynamicRouter::CONTENT_KEY`` (which evaluates to ``contentDocument``).
+The name of the request attribute which contains the content object. This is
+used by the ContentListener to exctract SEO information automatically. If the
+RoutingBundle is present, this defaults to ``DynamicRouter::CONTENT_KEY``
+(which evaluates to ``contentDocument``), otherwise you must define this
+manually or disable the listener.
 
 sonata_admin_extension
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -129,15 +131,15 @@ form_group
 The name of the form group of the group provided by the Sonata Admin
 Extension.
 
-``enable_content_listener``
-"""""""""""""""""""""""""""
+content_listener
+""""""""""""""""
 
 .. versionadded:: 1.1
-    The ``enable_content_listener`` configuration key was introduced in SeoBundle 1.1
+The ``content_listener`` configuration key was introduced in SeoBundle 1.1.1
+
+enabled
+~~~~~~~
 
 **type**: ``boolean`` **default**: ``true``
 
-Whether or not the ``Symfony\Cmf\Bundle\SeoBundle\EventListener\ContentListener`` should be loaded
-as a ``kernel.request`` listener. The ContentListener is responsible for extracting SEO data from
-CMF content documents. Set this to false to disable the listener. If you want to use your own content listener
-you will need to register your listener as a service and tag it as a ``kernel.request`` listener.
+Whether or not the :ref:`bundles-seo-content-listener` should be loaded.

--- a/bundles/seo/introduction.rst
+++ b/bundles/seo/introduction.rst
@@ -62,7 +62,7 @@ The simplest use of this bundle would be to just set some configuration to the
                 ),
             ),
         ));
-    
+
 The only thing to do now is to use the twig helper in your templates:
 
 .. code-block:: html+jinja
@@ -105,11 +105,9 @@ document. This metadata can hold:
 * Anything else that uses the ``<meta>`` tag with the ``property``, ``name``
   or ``http-equiv`` type (e.g. Open Graph data).
 
-The content object is retrieved from the request attributes. By default, it
-uses the ``DynamicRouter::CONTENT_KEY`` constant when the
-:doc:`RoutingBundle <../routing/introduction>` is installed. To change this,
-or if you don't use the RoutingBundle, you can configure it with
-``cmf_seo.content_key``.
+Extracting Metadata
+~~~~~~~~~~~~~~~~~~~
+
 This bundle provides two ways of using this metadata:
 
 #. Implementing the ``SeoAwareInterface`` and persisting the ``SeoMetadata``
@@ -131,6 +129,24 @@ Both ways are documented in detail in separate sections:
 
 * :doc:`seo_aware`
 * :doc:`extractors`
+
+.. _bundles-seo-content-listener
+
+The ContentListener
+~~~~~~~~~~~~~~~~~~~
+
+The ``Symfony\Cmf\Bundle\SeoBundle\EventListener\ContentListener`` looks for a
+content document in the request attributes. If it finds a document that is
+suitable for extracting metadata, it does so to populate the metadata
+information store.
+
+If the :doc:`RoutingBundle <../routing/introduction>` is installed, the default
+attribute name is defined by the constant ``DynamicRouter::CONTENT_KEY``. When
+not using the RoutingBundle, you need to disable the listener or configure a
+key in ``cmf_seo.content_key``.
+
+You may also want to disable this listener when implementing your own mechanism
+to extract SEO information.
 
 Choosing the Original Route Pattern
 -----------------------------------


### PR DESCRIPTION
explaining the content listener...

the content changes are now in #651

once that is merged, extract the relevant information from here and do a new PR against master (as the seo content listener enabled is not in 1.2 anymore)