### PR TITLE
Fixed misprint (getOptions() -> getSettings)

### DIFF
--- a/bundles/block/create_your_own_blocks.rst
+++ b/bundles/block/create_your_own_blocks.rst
@@ -145,7 +145,7 @@ that knows how to fetch the feed data of an ``RssBlock``::
             $settings = $blockContext->getSettings();
             $resolver = new OptionsResolver();
             $resolver->setDefaults($settings);
-            $settings = $resolver->resolve($block->getOptions());
+            $settings = $resolver->resolve($block->getSettings());
 
             $feeds = false;
             if ($settings['url']) {


### PR DESCRIPTION
Actually there should be `getSettings` call