### PR TITLE
Update to introduction.rst

### DIFF
--- a/bundles/seo/introduction.rst
+++ b/bundles/seo/introduction.rst
@@ -8,7 +8,7 @@ Installation
 ------------
 
 You can install this bundle `with composer`_ using the
-``symfony-cmf/seo-content-bundle`` package on `Packagist`_.
+``symfony-cmf/seo-bundle`` package on `Packagist`_.
 
 Both the CmfSeoBundle and SonataSeoBundle must be registered in the
 ``AppKernel``::


### PR DESCRIPTION
Typo: there is no "symfony-cmf/seo-content-bundle", but "symfony-cmf/seo-bundle". Changed to avoid confusion.