### PR TITLE
Add config per instance according documentation of FMElfinderBundle

### DIFF
--- a/bundles/media/adapters/elfinder.rst
+++ b/bundles/media/adapters/elfinder.rst
@@ -22,15 +22,17 @@ Installation
 
            # app/config/config.yml
            fm_elfinder:
-               locale: "%locale%"
-               editor: ckeditor
-               connector:
-                   roots:
-                       media:
-                           driver: cmf_media.adapter.elfinder.phpcr_driver
-                           path: "%cmf_media.persistence.phpcr.media_basepath%"
-                           upload_allow: ['all']
-                           upload_max_size: 2M
+                instances:
+                    default:
+                       locale: "%locale%"
+                       editor: ckeditor
+                       connector:
+                           roots:
+                               media:
+                                   driver: cmf_media.adapter.elfinder.phpcr_driver
+                                   path: "%cmf_media.persistence.phpcr.media_basepath%"
+                                   upload_allow: ['all']
+                                   upload_max_size: 2M
 
        .. code-block:: xml
 


### PR DESCRIPTION
Hi guys,

According doc presents in https://github.com/helios-ag/FMElfinderBundle#step-1-installation

we have to add a level configuration for elfinder, without it we get an InvalidConfigurationException
```php
  [Symfony\Component\Config\Definition\Exception\InvalidConfigurationException]  
  Unrecognized options "locale, editor, connector" under "fm_elfinder"    
```