### PR TITLE
Add SimpleCmsBundle in the AppKernel bundles list

### DIFF
--- a/bundles/simple_cms/introduction.rst
+++ b/bundles/simple_cms/introduction.rst
@@ -46,6 +46,7 @@ them and their dependencies need to be instantiated in the kernel::
                 new Symfony\Cmf\Bundle\MenuBundle\CmfMenuBundle(),
                 new Symfony\Cmf\Bundle\ContentBundle\CmfContentBundle(),
                 new Symfony\Cmf\Bundle\RoutingBundle\CmfRoutingBundle(),
+                new Symfony\Cmf\Bundle\SimpleCmsBundle\CmfSimpleCmsBundle(),
             );
 
             // ...


### PR DESCRIPTION
In the installation documentation, we should add the SimpleCmsBundle in order to have a working example.