### PR TITLE
add note that form types only work with phpcr

### DIFF
--- a/bundles/media/form_types.rst
+++ b/bundles/media/form_types.rst
@@ -7,6 +7,12 @@ Form Types
 The MediaBundle provides a couple of useful form types along with form data
 transformers.
 
+.. caution::
+
+    The form types described in this chapter are only available if the PHPCR storage
+    is activated. Implementation for other storage systems would be welcome 
+    contributions.
+
 A default twig template is also included for these form types.
 To use it you will need to add the ``fields.html.twig`` template from the 
 MediaBundle to the ``form.resources`` section in twig config:


### PR DESCRIPTION
not the first time people ask how to use the form types but not having phpcr enabled... and the documentation is not clear on this.
http://stackoverflow.com/questions/33572288/symfony-cmf-media-bundle-form-type-not-recognised-could-not-load-type-cmf-med/33588605#33588605