### PR TITLE
[Routing] Fixing 'Creating the Route Provider' example

### DIFF
--- a/bundles/routing/dynamic_customize.rst
+++ b/bundles/routing/dynamic_customize.rst
@@ -91,12 +91,14 @@ following class provides a simple solution using an ODM Repository.
             $document = $this->findOneBy(array(
                 'name' => $name,
             ));
-
-            if ($route) {
-                $route = new SymfonyRoute($route->getPattern(), array(
-                    'document' => $document,
-                ));
+            
+            if (!$document) {
+                throw new RouteNotFoundException("No route found for name '$name'");
             }
+
+            $route = new SymfonyRoute($document->getUrl(), array(
+                'document' => $document,
+            ));
 
             return $route;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Doc fix?      | yes
| New docs?     | no
| Applies to    | all
| Fixed tickets |n/a

Customizing the Dynamic Router > Using a Custom Route Provider > Creating the Route Provider > getRouteByName method [link](https://github.com/symfony-cmf/symfony-cmf-docs/blame/master/bundles/routing/dynamic_customize.rst#L89-L103):
```php
/**
 * This method is used to generate URLs, e.g. {{ path('foobar') }}.
 */
public function getRouteByName($name, $params = array())
{
    $document = $this->findOneBy(array(
        'name' => $name,
    ));

    // <--- missing RouteNotFoundException if $document is null

    if ($route) { // <--- undefined variable $route
        $route = new SymfonyRoute($route->getPattern(), array( // <--- undefined variable $route
            'document' => $document,
        ));
    }

    return $route;
}
```