### PR TITLE
[Routing] Adding missing parameter

### DIFF
--- a/components/routing/nested_matcher.rst
+++ b/components/routing/nested_matcher.rst
@@ -67,7 +67,7 @@ following methods::
             }
 
             foreach ($routes as $route) {
-                $collection->add($route);
+                $collection->add($route->getName(), $route);
             }
 
             return $collection;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Doc fix?      | yes
| New docs?     | no
| Applies to    | all
| Fixed tickets |n/a

Added the name of the route in `RouteCollection::add` method: https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Routing/RouteCollection.php#L75