### PR TITLE
add note that custom url generator was added in version 1.4

### DIFF
--- a/bundles/routing/dynamic_customize.rst
+++ b/bundles/routing/dynamic_customize.rst
@@ -91,7 +91,7 @@ following class provides a simple solution using an ODM Repository.
             $document = $this->findOneBy(array(
                 'name' => $name,
             ));
-            
+
             if (!$document) {
                 throw new RouteNotFoundException("No route found for name '$name'");
             }
@@ -152,7 +152,10 @@ provider. See `Creating and configuring services in the container`_ for
 information on creating custom services.
 
 Using a Custom URL Generator
-----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.4
+    The configuration option to specify a custom URL generator was introduced in CmfRoutingBundle 1.4.
 
 The dynamic router can also generate URLs from route objects. If you need to
 customize this behavior beyond what the


### PR DESCRIPTION
that warning was missing and lead to confusion: http://stackoverflow.com/questions/34539481/unrecognized-config-option-url-generator/34565452#34565452