### PR TITLE
Fixes #735: Replace deprecated annotations:

### DIFF
--- a/book/database_layer.rst
+++ b/book/database_layer.rst
@@ -114,12 +114,12 @@ class via annotations:
             protected $id;
 
             /**
-             * @PHPCR\String()
+             * @PHPCR\Field(type="string")
              */
             protected $description;
 
             /**
-             * @PHPCR\Boolean()
+             * @PHPCR\Field(type="boolean")
              */
             protected $done = false;
 

--- a/book/handling_multilang.rst
+++ b/book/handling_multilang.rst
@@ -107,7 +107,7 @@ always happens on a document level, not on the individual translatable fields.
     {
         /**
          * Translated property
-         * @PHPCR\String(translated=true)
+         * @PHPCR\Field(type="string", translated=true)
          */
         private $topic;
 

--- a/bundles/block/create_your_own_blocks.rst
+++ b/bundles/block/create_your_own_blocks.rst
@@ -45,12 +45,12 @@ for instance ``acme_main.block.rss``::
     class RssBlock extends AbstractBlock
     {
         /**
-         * @PHPCR\String(nullable=true)
+         * @PHPCR\Field(type="string", nullable=true)
          */
         private $feedUrl;
 
         /**
-         * @PHPCR\String()
+         * @PHPCR\Field(type="string")
          */
         private $title;
 

--- a/bundles/phpcr_odm/multilang.rst
+++ b/bundles/phpcr_odm/multilang.rst
@@ -139,7 +139,7 @@ depending on the locale.
 
             /**
              * Translated property
-             * @PHPCR\String(translated=true)
+             * @PHPCR\Field(type="string", translated=true)
              */
             private $topic;
 

--- a/tutorial/getting-started.rst
+++ b/tutorial/getting-started.rst
@@ -112,7 +112,7 @@ to reduce code duplication::
         protected $title;
 
         /**
-         * @PHPCR\String(nullable=true)
+         * @PHPCR\Field(type='string', nullable=true)
          */
         protected $content;
 


### PR DESCRIPTION
    @PHPCR\String() → @PHPCR\Field(type="string")
    @PHPCR\Boolean() → @PHPCR\Field(type="boolean")