### PR TITLE
Revert "Revert "Documentation for multiple auto routes feature""

### DIFF
--- a/bundles/routing_auto/definitions.rst
+++ b/bundles/routing_auto/definitions.rst
@@ -1,0 +1,99 @@
+.. index::
+    single: Definitions; RoutingAutoBundle
+
+Multiple Auto Routes
+====================
+
+In the introduction you were shown an example using a single auto route schema
+definition. It is possible to have multiple auto-route definitions for each of your
+managed objects, and therefore multiple routes.
+
+Below we will modify the example given in the :doc:`Introduction
+<introduction>` and add a
+new ``edit`` schema definition which has the ``/admin`` prefix:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # src/Acme/ForumBundle/Resources/config/cmf_routing_auto.yml
+        Acme\ForumBundle\Document\Topic:
+            definitions: 
+                 main:
+                     uri_schema: /my-forum/{category}/{title}
+                     defaults:
+                         type: view
+                 edit:
+                     uri_schema: /admin/my-forum/{category}/{title}
+                     defaults:
+                         type: edit
+            token_providers:
+                category: [content_method, { method: getCategoryTitle, slugify: true }]
+                title: [content_method, { method: getTitle }] # slugify is true by default
+
+    .. code-block:: xml
+
+        <!-- src/Acme/ForumBundle/Resources/config/cmf_routing_auto.xml -->
+        <?xml version="1.0" ?>
+        <auto-mapping xmlns="http://cmf.symfony.com/schema/routing_auto">
+            <mapping class="Acme\ForumBundle\Document\Topic">
+                <definition name="main" uri-schema="/my-forum/{category}/{title}">
+                    <default key="type">view</default>
+                </definition>
+
+                <definition name="edit" uri-schema="/admin/my-forum/{category}/{title}">
+                    <default key="type">edit</default>
+                </definition>
+
+                <token-provider token="category" name="content_method">
+                    <option name="method">getCategoryName</option>
+                    <option name="slugify">true</option>
+                </token-provider>
+
+                <token-provider token="title" name="content_method">
+                    <option name="method">getTitle</option>
+                </token-provider>
+            </mapping>
+        </auto-mapping>
+
+Note that we specify the ``defaults``. The ``defaults`` key can be used to
+persist key / value information on a route. This information can later be used
+for many things, but importantly it can be used by the :doc:`Dynamic Router
+<../routing/dynamic>` to determine which controller should be used to handle
+the request.
+
+For example, the dynamic router could be configured as follows:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config/config.yml
+        cmf_routing:
+            # ...
+            dynamic:
+                # ...
+                controllers_by_type:
+                    view: Acme\\BasicCmsBundle\\Controller\\ViewController
+                    edit: Acme\\BasicCmsBundle\\Controller\\ViewController
+
+    .. code-block:: xml
+
+        <!-- app/config/config.xml -->
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <container xmlns="http://symfony.com/schema/dic/services">
+            <config xmlns="http://cmf.symfony.com/schema/dic/routing">
+                <! -- ... -->
+                <dynamic>
+                    <! -- ... -->
+                    <controller-by-type
+                        type="view">
+                        Acme\\BasicCmsBundle\\Controller\\ViewController
+                    </controller-by-type>
+                    <controller-by-type
+                        type="edit">
+                        Acme\\BasicCmsBundle\\Controller\\EditController
+                    </controller-by-type>
+                </dynamic>
+            </config>
+        </container>

--- a/bundles/routing_auto/definitions.rst
+++ b/bundles/routing_auto/definitions.rst
@@ -4,6 +4,11 @@
 Multiple Auto Routes
 ====================
 
+.. versionadded: 2.0
+
+    The capability to add multiple routes for a managed object has been
+    introduced in RoutingAutoBundle 2.0.
+
 In the introduction you were shown an example using a single auto route schema
 definition. It is possible to have multiple auto-route definitions for each of your
 managed objects, and therefore multiple routes.
@@ -18,7 +23,7 @@ new ``edit`` schema definition which has the ``/admin`` prefix:
 
         # src/Acme/ForumBundle/Resources/config/cmf_routing_auto.yml
         Acme\ForumBundle\Document\Topic:
-            definitions: 
+            definitions:
                  main:
                      uri_schema: /my-forum/{category}/{title}
                      defaults:

--- a/bundles/routing_auto/defunct_route_handlers.rst
+++ b/bundles/routing_auto/defunct_route_handlers.rst
@@ -92,7 +92,7 @@ can be configured as follows:
                     <controller-by-type
                         type="cmf_routing_auto.redirect">
                         cmf_routing_auto.redirect_controller:redirectAction
-                    </controller-by-class>
+                    </controller-by-type>
                 </dynamic>
             </config>
 

--- a/bundles/routing_auto/index.rst
+++ b/bundles/routing_auto/index.rst
@@ -8,4 +8,4 @@ RoutingAutoBundle
     token_providers
     conflict_resolvers
     defunct_route_handlers
-
+    definitions

--- a/bundles/routing_auto/introduction.rst
+++ b/bundles/routing_auto/introduction.rst
@@ -2,8 +2,8 @@
     single: RoutingAuto; Bundles
     single: RoutingAutoBundle
 
-Introduction
-============
+RoutingAutoBundle
+=================
 
 The RoutingAutoBundle allows you to automatically persist routes when
 documents are persisted based on URI schemas and contextual information.
@@ -120,7 +120,7 @@ document could be defined as follows:
 
         # src/Acme/ForumBundle/Resources/config/cmf_routing_auto.yml
         Acme\ForumBundle\Document\Topic:
-            definitions: 
+            definitions:
                  main:
                      uri_schema: /my-forum/{category}/{title}
             token_providers:

--- a/bundles/routing_auto/introduction.rst
+++ b/bundles/routing_auto/introduction.rst
@@ -2,8 +2,8 @@
     single: RoutingAuto; Bundles
     single: RoutingAutoBundle
 
-RoutingAutoBundle
-=================
+Introduction
+============
 
 The RoutingAutoBundle allows you to automatically persist routes when
 documents are persisted based on URI schemas and contextual information.
@@ -93,7 +93,7 @@ forum topic with the following fictional URI:
 
 - ``https://mywebsite.com/my-forum/drinks/coffee``
 
-The RoutingAutoBundle uses a URI schema to define how routes are generated. A
+The RoutingAutoBundle uses a URI schema definitions to define how routes are generated. A
 schema for the above URI would look like this (the bundle does not care about
 the host or protocol):
 
@@ -105,7 +105,7 @@ You can see that ``my-forum`` is static (it will not change) but that
 
 The value for tokens are provided by *token providers*.
 
-The schema, token providers, and other configurations (more on this later) are
+The schema definitions, token providers, and other configurations (more on this later) are
 contained within ``routing_auto.format`` files (currently ``xml`` and ``yaml`` are
 supported). These files are contained either in your bundles
 ``Resources/config`` directory or in a custom location specified in
@@ -120,7 +120,9 @@ document could be defined as follows:
 
         # src/Acme/ForumBundle/Resources/config/cmf_routing_auto.yml
         Acme\ForumBundle\Document\Topic:
-            uri_schema: /my-forum/{category}/{title}
+            definitions: 
+                 main:
+                     uri_schema: /my-forum/{category}/{title}
             token_providers:
                 category: [content_method, { method: getCategoryTitle, slugify: true }]
                 title: [content_method, { method: getTitle }] # slugify is true by default
@@ -130,7 +132,9 @@ document could be defined as follows:
         <!-- src/Acme/ForumBundle/Resources/config/cmf_routing_auto.xml -->
         <?xml version="1.0" ?>
         <auto-mapping xmlns="http://cmf.symfony.com/schema/routing_auto">
-            <mapping class="Acme\ForumBundle\Document\Topic" uri-schema="/my-forum/{category}/{title}">
+            <mapping class="Acme\ForumBundle\Document\Topic">
+                <definition name="main" uri-schema="/my-forum/{category}/{title}" />
+
                 <token-provider token="category" name="content_method">
                     <option name="method">getCategoryName</option>
                     <option name="slugify">true</option>
@@ -186,6 +190,7 @@ Read more
 * :doc:`token_providers`
 * :doc:`conflict_resolvers`
 * :doc:`defunct_route_handlers`
+* :doc:`definitions`
 
 .. _`with composer`: https://getcomposer.org/
 .. _`symfony-cmf/routing-auto-bundle`: https:/packagist.org/packages/symfony-cmf/routing-auto-bundle


### PR DESCRIPTION
re-add the documentation for https://github.com/symfony-cmf/RoutingAuto/pull/62 that was accidentally merged too fast in #731