### PR TITLE
Update the_router.rst

### DIFF
--- a/quick_tour/the_router.rst
+++ b/quick_tour/the_router.rst
@@ -96,7 +96,8 @@ new routes in ``/cms/routes``:
             dynamic:
                 persistence:
                     phpcr:
-                        route_basepaths: /cms/routes
+                        route_basepaths:
+                            - /cms/routes
                     # /cms/routes is the default base path, the above code is
                     # equivalent to:
                     # phpcr: true


### PR DESCRIPTION
I have received this error when I run server with `php app/console server:run`
> Invalid type for path "cmf_routing.dynamic.persistence.phpcr.route_basepaths". Expected array, but got string

Seeing this page, the way I changed looks proper.
http://symfony.com/doc/current/cmf/bundles/routing/configuration.html#phpcr