### PR TITLE
adjust links to repository renaming

### DIFF
--- a/book/handling_multilang.rst
+++ b/book/handling_multilang.rst
@@ -347,4 +347,4 @@ save the edited document in the same language as it was loaded.
 .. _`this discussion about ICU`: https://github.com/symfony/symfony/issues/5279#issuecomment-11710480
 .. _`cmf-sandbox config.yml file`: https://github.com/symfony-cmf/cmf-sandbox/blob/master/app/config/config.yml
 .. _`PHPCR-ODM documentation on multi-language`: http://docs.doctrine-project.org/projects/doctrine-phpcr-odm/en/latest/reference/multilang.html
-.. _`issue`: https://github.com/symfony-cmf/CreateBundle/issues/39
+.. _`issue`: https://github.com/symfony-cmf/create-bundle/issues/39

--- a/bundles/block/introduction.rst
+++ b/bundles/block/introduction.rst
@@ -420,4 +420,4 @@ Read on
 .. _`Symfony CMF Sandbox`: https://github.com/symfony-cmf/cmf-sandbox
 .. _`prepended configuration`: https://symfony.com/doc/current/components/dependency_injection/compilation.html#prepending-configuration-passed-to-the-extension
 .. _`SonataBlockBundle`: https://github.com/sonata-project/SonataBlockBundle
-.. _`discussion how to fix this`: https://github.com/symfony-cmf/BlockBundle/issues/143
+.. _`discussion how to fix this`: https://github.com/symfony-cmf/block-bundle/issues/143

--- a/bundles/content/exposing_content_via_rest.rst
+++ b/bundles/content/exposing_content_via_rest.rst
@@ -154,4 +154,4 @@ for details.
 .. _`FOSRestBundle view layer`: https://symfony.com/doc/master/bundles/FOSRestBundle/2-the-view-layer.html
 .. _Composer: https://getcomposer.org/
 .. _`documentation of the JMS serializer`: http://jmsyst.com/libs/#serializer
-.. _`default response format changed between 1.0 and 1.1 of the ContentBundle`: https://github.com/symfony-cmf/ContentBundle/pull/91
+.. _`default response format changed between 1.0 and 1.1 of the ContentBundle`: https://github.com/symfony-cmf/content-bundle/pull/91

--- a/bundles/create/other-editors.rst
+++ b/bundles/create/other-editors.rst
@@ -114,4 +114,4 @@ editor parameter:
     help, please see the github issue for `aloha`_ integration.
 
 .. _`Aloha editor`: http://www.alohaeditor.org/Content.Node/index.html
-.. _`aloha`: https://github.com/symfony-cmf/CreateBundle/issues/32
+.. _`aloha`: https://github.com/symfony-cmf/create-bundle/issues/32

--- a/bundles/media/form_types.rst
+++ b/bundles/media/form_types.rst
@@ -10,11 +10,11 @@ transformers.
 .. caution::
 
     The form types described in this chapter are only available if the PHPCR storage
-    is activated. Implementation for other storage systems would be welcome 
+    is activated. Implementation for other storage systems would be welcome
     contributions.
 
 A default twig template is also included for these form types.
-To use it you will need to add the ``fields.html.twig`` template from the 
+To use it you will need to add the ``fields.html.twig`` template from the
 MediaBundle to the ``form.resources`` section in twig config:
 
 .. configuration-block::
@@ -153,7 +153,7 @@ cmf_media_file
 
 .. versionadded: 1.3
     The ``cmf_media_file`` form type was introduced in MediaBundle 1.3.
-    
+
 The ``cmf_media_file`` form maps to an object that implements the
 ``Symfony\Cmf\Bundle\MediaBundle\FileInterface``.
 It renders as a file upload button with a link for downloading the existing
@@ -161,5 +161,5 @@ file, if any.
 
 .. _`LiipImagineBundle`: https://github.com/liip/LiipImagineBundle
 .. _`trying to make this automatic`: https://groups.google.com/forum/?fromgroups=#!topic/symfony2/CrooBoaAlO4
-.. _`ImagineBlock::setImage`: https://github.com/symfony-cmf/BlockBundle/blob/master/Doctrine/Phpcr/ImagineBlock.php#L121
-.. _`MediaBundle issue`: https://github.com/symfony-cmf/MediaBundle/issues/9
+.. _`ImagineBlock::setImage`: https://github.com/symfony-cmf/block-bundle/blob/master/Doctrine/Phpcr/ImagineBlock.php#L121
+.. _`MediaBundle issue`: https://github.com/symfony-cmf/media-bundle/issues/9

--- a/bundles/media/introduction.rst
+++ b/bundles/media/introduction.rst
@@ -217,7 +217,7 @@ The media bundle contains a Twig extension, it contains the following functions:
           <img src="<?php echo $view['cmf_media']->displayUrl($image) ?>" alt="" />
 
     If :doc:`LiipImagine <adapters/liip_imagine>` is enabled you can also pass :doc:`filter </bundles/LiipImagineBundle/filters>` and `runtime_config` like below:
-    
+
       .. code-block:: html+jinja
 
         <a href="{{ cmf_media_display_url(file, {
@@ -288,7 +288,7 @@ and Symfony bundles:
 
 .. _`symfony-cmf/media-bundle`: https://packagist.org/packages/symfony-cmf/media-bundle
 .. _`with composer`: https://getcomposer.org
-.. _`MediaBundle`: https://github.com/symfony-cmf/MediaBundle#readme
+.. _`MediaBundle`: https://github.com/symfony-cmf/media-bundle#readme
 .. _`KnpLabs/Gaufrette`: https://github.com/KnpLabs/Gaufrette
 .. _`phpcr/phpcr-utils`: https://github.com/phpcr/phpcr-utils
 .. _`jms/serializer-bundle`: https://github.com/schmittjoh/JMSSerializerBundle

--- a/bundles/routing/introduction.rst
+++ b/bundles/routing/introduction.rst
@@ -106,7 +106,7 @@ For more information on Routing in the Symfony CMF, please refer to:
 
 .. _`with composer`: https://getcomposer.org
 .. _`symfony-cmf/routing-bundle`: https://packagist.org/packages/symfony-cmf/routing-bundle
-.. _`RoutingBundle`: https://github.com/symfony-cmf/RoutingBundle#readme
+.. _`RoutingBundle`: https://github.com/symfony-cmf/routing-bundle#readme
 .. _`PHPCR-ODM`: http://www.doctrine-project.org/projects/phpcr-odm.html
 .. _`documentation for DependencyInjection tags`: https://symfony.com/doc/2.1/reference/dic_tags.html
 .. _`Routing`: https://symfony.com/doc/current/components/routing/introduction.html

--- a/bundles/simple_cms/multilang.rst
+++ b/bundles/simple_cms/multilang.rst
@@ -53,4 +53,4 @@ need to reload the content after the routing step to get the requested locale.
     You can also completely separate routing and content by using the separate
     documents from the RoutingBundle and ContentBundle.
 
-.. _`issue tracker`: https://github.com/symfony-cmf/SimpleCmsBundle/issues/109
+.. _`issue tracker`: https://github.com/symfony-cmf/simple-cms-bundle/issues/109

--- a/contributing/bundles.rst
+++ b/contributing/bundles.rst
@@ -250,6 +250,6 @@ instructions on how the component should be integrated.
 .. _`XML in the configuration class`: https://symfony.com/doc/current/components/config/definition.html#normalization
 .. _`XML schema`: https://en.wikipedia.org/wiki/.xsd
 .. _`XLIFF format`: https://symfony.com/doc/current/book/translation.html#basic-translation
-.. _`CONTRIBUTING file from CoreBundle`: https://github.com/symfony-cmf/CoreBundle/blob/master/CONTRIBUTING.md
+.. _`CONTRIBUTING file from CoreBundle`: https://github.com/symfony-cmf/core-bundle/blob/master/CONTRIBUTING.md
 .. _`LICENSE template on wiki`: https://github.com/symfony-cmf/symfony-cmf/wiki/LICENSE-Template
 .. _`service naming conventions`: https://symfony.com/doc/current/contributing/code/standards.html#service-naming-conventions

--- a/tutorial/the-frontend.rst
+++ b/tutorial/the-frontend.rst
@@ -289,5 +289,5 @@ fixtures.
 
 .. _`knpmenubundle`: https://github.com/KnpLabs/KnpMenuBundle
 .. _`knpmenu`: https://github.com/KnpLabs/KnpMenu
-.. _`MenuBundle`: https://github.com/symfony-cmf/MenuBundle
-.. _`CoreBundle`: https://github.com/symfony-cmf/CoreBundle
+.. _`MenuBundle`: https://github.com/symfony-cmf/menu-bundle
+.. _`CoreBundle`: https://github.com/symfony-cmf/core-bundle


### PR DESCRIPTION
now that we renamed the repositories, we should also adjust the links to them. the old names redirect, but this is nonetheless more elegant.