### PR TITLE
Changed the quick tour to use version 1.2 of the Standard Edition.

### DIFF
--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -45,8 +45,16 @@ The best way to download the Symfony CMF Standard Edition is using Composer_:
 
 .. code-block:: bash
 
-    $ composer create-project symfony-cmf/standard-edition cmf '~1.2'
+    $ composer create-project symfony-cmf/standard-edition cmf '1.2'
 
+.. note::
+
+   The `AcmeDemoBundle` that is used in this tour was removed in
+   version 1.3 of the Symfony CMF Standard Edition.  Since then it has
+   become the skeleton for a simple CMS application.  This is why we
+   install version 1.2.  If you insist on checking out the most recent
+   versions of the CMF, check out `symfony-cmf/cmf-sandbox`.
+    
 Setting up the Database
 ~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The quick tour references the AcmeDemoBundle of the CMF Standard
Edition a lot, but this bundle was removed in version 1.3.  Hence,
specific versioning should be used, instead of tilde matching.

This fixes #759. Since I just spent half an hour looking for the right package, I just decided to fix this.