### PR TITLE
decoupledcms.org will go offline

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -97,7 +97,7 @@ Do you want to contribute to the Symfony CMF? Start reading these articles!
 
 :doc:`Browse the contributing guide <contributing/index>`
 
-.. _`decoupled CMS`: http://decoupledcms.org
+.. _`decoupled CMS`: http://bergie.iki.fi/blog/decoupling_content_management/
 .. _`Symfony2`: https://symfony.com
 .. _`Documentation planning`: https://github.com/symfony-cmf/symfony-cmf/wiki/Documentation-Planning
 .. _`Symfony Content Management Framework`: http://cmf.symfony.com


### PR DESCRIPTION
@lsmith77 if i understood your tweets correctly, this domain will either go away or be repurposed. does it make sense to change the symfony cmf doc link to bergie's blogpost, or should we write a bit on decoupled cms in the doc itself?
