### PR TITLE
add unmaintained notice to the bundles that are no longer maintained

### DIFF
--- a/bundles/_partials/unmaintained.rst.inc
+++ b/bundles/_partials/unmaintained.rst.inc
@@ -1,0 +1,12 @@
+.. note::
+
+    To focus our efforts onto a manageable number of packages, this package is
+    currently *not* maintained. Security fixes and submitted bug fixes will
+    still be released, but no new features should be expected. This bundle
+    might have outdated documentation, there is no support from the CMF team
+    and you should not expect bugs to be fixed.
+
+    If you want to help co-maintaining this package, tell us in a GitHub issue
+    or in #symfony_cmf of the `Symfony devs slack`_.
+
+.. _`Symfony devs slack`: https://slackinvite.me/to/symfony-devs

--- a/bundles/create/configuration.rst
+++ b/bundles/create/configuration.rst
@@ -1,6 +1,8 @@
 Configuration Reference
 =======================
 
+.. include:: ../_partials/unmaintained.rst.inc
+
 The CreateBundle can be configured under the ``cmf_create`` key in your
 application configuration. When using XML you should use the
 ``http://cmf.symfony.com/schema/dic/create`` namespace.

--- a/bundles/create/developing-hallo.rst
+++ b/bundles/create/developing-hallo.rst
@@ -4,6 +4,8 @@ Developing the Hallo Wysiwyg Editor
     You can use the CreateBundle as a development testbed for the hallo.js
     editor.
 
+.. include:: ../_partials/unmaintained.rst.inc
+
 A compiled and minimized version of `hallo.js`_ is bundled with create.js. To
 develop the actual code, you will need to checkout the full
 `hallo.js repository`_ first. You can do this by running the following command

--- a/bundles/create/index.rst
+++ b/bundles/create/index.rst
@@ -1,6 +1,8 @@
 CreateBundle
 ============
 
+.. include:: ../_partials/unmaintained.rst.inc
+
 .. toctree::
     :maxdepth: 2
 

--- a/bundles/create/introduction.rst
+++ b/bundles/create/introduction.rst
@@ -9,6 +9,8 @@ CreateBundle
     applications. It integrates create.js and the CreatePHP library into
     Symfony2.
 
+.. include:: ../_partials/unmaintained.rst.inc
+
 The JavaScript library `create.js`_ provides a comprehensive web editing
 interface for Content Management Systems. It is designed to provide a modern,
 fully browser-based HTML5 environment for managing content. Create.js can be

--- a/bundles/create/other-editors.rst
+++ b/bundles/create/other-editors.rst
@@ -5,6 +5,8 @@ Other Editors
     your own template to load a different editor or customize one of the
     existing editors is configured.
 
+.. include:: ../_partials/unmaintained.rst.inc
+
 .. _bundle-create-hallo:
 
 Using Hallo.js Editor

--- a/bundles/map.rst.inc
+++ b/bundles/map.rst.inc
@@ -23,20 +23,6 @@ library or they introduce a complete new concept.
   * :doc:`core/forms`
   * :doc:`core/configuration`
 
-* :doc:`create/index`
-
-  * :doc:`create/introduction`
-  * :doc:`create/other-editors`
-  * :doc:`create/developing-hallo`
-  * :doc:`create/configuration`
-
-* :doc:`media/index`
-
-  * :doc:`media/introduction`
-  * :doc:`media/form_types`
-  * :doc:`media/adapters/index`
-  * :doc:`media/configuration`
-
 * :doc:`menu/index`
 
   * :doc:`menu/introduction`
@@ -60,11 +46,6 @@ library or they introduce a complete new concept.
   * :doc:`routing_auto/token_providers`
   * :doc:`routing_auto/conflict_resolvers`
   * :doc:`routing_auto/defunct_route_handlers`
-
-* :doc:`search/index`
-
-  * :doc:`search/introduction`
-  * :doc:`search/configuration`
 
 * :doc:`seo/index`
 
@@ -103,15 +84,6 @@ bundle based on the key bundles.
   * :doc:`content/configuration`
   * :doc:`content/exposing_content_via_rest`
 
-* :doc:`simple_cms/index`
-
-  * :doc:`simple_cms/introduction`
-  * :doc:`simple_cms/multilang`
-  * :doc:`simple_cms/rendering`
-  * :doc:`simple_cms/menus`
-  * :doc:`simple_cms/extending_page_class`
-  * :doc:`simple_cms/configuration`
-
 Contributed Bundles
 ~~~~~~~~~~~~~~~~~~~
 
@@ -127,5 +99,39 @@ help with integrating PHPCR concepts into the Symfony Framework.
   * :doc:`phpcr_odm/multilang`
   * :doc:`phpcr_odm/multiple_sessions`
   * :doc:`phpcr_odm/configuration`
+
+Unmaintained Bundles
+~~~~~~~~~~~~~~~~~~~~
+
+The following bundles were created for the CMF, but to focus our efforts on the
+core components, they are currently unmaintained.
+
+* :doc:`create/index`
+
+  * :doc:`create/introduction`
+  * :doc:`create/other-editors`
+  * :doc:`create/developing-hallo`
+  * :doc:`create/configuration`
+
+* :doc:`media/index`
+
+  * :doc:`media/introduction`
+  * :doc:`media/form_types`
+  * :doc:`media/adapters/index`
+  * :doc:`media/configuration`
+
+* :doc:`search/index`
+
+  * :doc:`search/introduction`
+  * :doc:`search/configuration`
+
+* :doc:`simple_cms/index`
+
+  * :doc:`simple_cms/introduction`
+  * :doc:`simple_cms/multilang`
+  * :doc:`simple_cms/rendering`
+  * :doc:`simple_cms/menus`
+  * :doc:`simple_cms/extending_page_class`
+  * :doc:`simple_cms/configuration`
 
 .. _SonataDoctrinePHPCRAdminBundle: https://sonata-project.org/bundles/doctrine-phpcr-admin/master/doc/index.html

--- a/bundles/media/adapters/elfinder.rst
+++ b/bundles/media/adapters/elfinder.rst
@@ -1,6 +1,8 @@
 elFinder
 ========
 
+.. include:: ../../_partials/unmaintained.rst.inc
+
 The media browser `elFinder`_ is integrated with Symfony using the
 `FMElfinderBundle`_. The MediaBundle provides an adapter to use it with objects
 implementing the MediaBundle interfaces.

--- a/bundles/media/adapters/gaufrette.rst
+++ b/bundles/media/adapters/gaufrette.rst
@@ -1,6 +1,8 @@
 Gaufrette
 =========
 
+.. include:: ../../_partials/unmaintained.rst.inc
+
 Gaufrette is a PHP5 library that provides a filesystem abstraction layer. The
 MediaBundle provides an adapter to use it with objects implementing the
 MediaBundle interfaces.

--- a/bundles/media/adapters/index.rst
+++ b/bundles/media/adapters/index.rst
@@ -1,6 +1,8 @@
 Adapters
 ========
 
+.. include:: ../../_partials/unmaintained.rst.inc
+
 .. toctree::
     :maxdepth: 2
 

--- a/bundles/media/adapters/liip_imagine.rst
+++ b/bundles/media/adapters/liip_imagine.rst
@@ -1,6 +1,8 @@
 LiipImagine
 ===========
 
+.. include:: ../../_partials/unmaintained.rst.inc
+
 For LiipImagine, a data loader is included:
 ``Symfony\Cmf\Bundle\MediaBundle\Adapter\LiipImagine\CmfMediaDoctrineLoader``.
 It will work for all image object implementing

--- a/bundles/media/configuration.rst
+++ b/bundles/media/configuration.rst
@@ -1,6 +1,8 @@
 Configuration Reference
 =======================
 
+.. include:: ../_partials/unmaintained.rst.inc
+
 The MediaBundle can be configured under the ``cmf_media`` key in your
 application configuration. When using XML, you can use the
 ``http://cmf.symfony.com/schema/dic/media`` namespace.

--- a/bundles/media/form_types.rst
+++ b/bundles/media/form_types.rst
@@ -4,8 +4,10 @@
 Form Types
 ----------
 
-The MediaBundle provides a couple of useful form types along with form data
-transformers.
+    The MediaBundle provides a couple of useful form types along with form data
+    transformers.
+
+.. include:: ../_partials/unmaintained.rst.inc
 
 .. caution::
 
@@ -134,7 +136,7 @@ Then you can add images to document forms as follows::
 The document that should contain the ``Image`` document has to implement a
 setter method. To profit from the automatic guesser of the form layer, the
 name in the form element and this method name have to match. See
-`ImagineBlock::setImage`_ for an example implementation.
+`ImagineBlock::setImage <ImagineBlock_setImage>`_ for an example implementation.
 
 To delete an image, you need to delete the document containing the image.
 (There is a proposal to improve the user experience for that in a
@@ -149,7 +151,7 @@ To delete an image, you need to delete the document containing the image.
     command or manually remove the imagine cache afterwards.
 
 cmf_media_file
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 .. versionadded: 1.3
     The ``cmf_media_file`` form type was introduced in MediaBundle 1.3.
@@ -161,5 +163,5 @@ file, if any.
 
 .. _`LiipImagineBundle`: https://github.com/liip/LiipImagineBundle
 .. _`trying to make this automatic`: https://groups.google.com/forum/?fromgroups=#!topic/symfony2/CrooBoaAlO4
-.. _`ImagineBlock::setImage`: https://github.com/symfony-cmf/block-bundle/blob/master/Doctrine/Phpcr/ImagineBlock.php#L121
+.. _`ImagineBlock_setImage`: https://github.com/symfony-cmf/block-bundle/blob/master/Doctrine/Phpcr/ImagineBlock.php#L121
 .. _`MediaBundle issue`: https://github.com/symfony-cmf/media-bundle/issues/9

--- a/bundles/media/index.rst
+++ b/bundles/media/index.rst
@@ -1,6 +1,8 @@
 MediaBundle
 ===========
 
+.. include:: ../_partials/unmaintained.rst.inc
+
 .. toctree::
     :maxdepth: 2
 

--- a/bundles/media/introduction.rst
+++ b/bundles/media/introduction.rst
@@ -9,6 +9,8 @@ MediaBundle
     a generic base of common interfaces and models that allow the user to build
     media management solutions for a CMS.
 
+.. include:: ../_partials/unmaintained.rst.inc
+
 Media can be images, binary documents (like pdf files), embedded movies,
 uploaded movies, MP3s, etc. The implementation of this bundle is **very**
 minimalistic and is focused on images and download files. If you need more

--- a/bundles/search/configuration.rst
+++ b/bundles/search/configuration.rst
@@ -1,6 +1,8 @@
 Configuration Reference
 =======================
 
+.. include:: ../_partials/unmaintained.rst.inc
+
 The SearchBundle can be configured under the ``cmf_search`` key in your
 application configuration. When using XML, you can use the
 ``http://cmf.symfony.com/schema/dic/search`` namespace.

--- a/bundles/search/index.rst
+++ b/bundles/search/index.rst
@@ -1,6 +1,8 @@
 SearchBundle
 ============
 
+.. include:: ../_partials/unmaintained.rst.inc
+
 .. toctree::
     :maxdepth: 2
 

--- a/bundles/search/introduction.rst
+++ b/bundles/search/introduction.rst
@@ -7,6 +7,8 @@ SearchBundle
     The SearchBundle provides integration with `LiipSearchBundle`_ to provide a
     site wide search.
 
+.. include:: ../_partials/unmaintained.rst.inc
+
 Installation
 ------------
 

--- a/bundles/simple_cms/configuration.rst
+++ b/bundles/simple_cms/configuration.rst
@@ -1,6 +1,8 @@
 Configuration Reference
 =======================
 
+.. include:: ../_partials/unmaintained.rst.inc
+
 The SimpleCmsBundle can be configured under the ``cmf_simple_cms`` key in your
 application configuration. When using XML, you can use the
 ``http://cmf.symfony.com/schema/dic/simplecms`` namespace.

--- a/bundles/simple_cms/extending_page_class.rst
+++ b/bundles/simple_cms/extending_page_class.rst
@@ -4,6 +4,8 @@
 Extending the Page class
 ------------------------
 
+.. include:: ../_partials/unmaintained.rst.inc
+
 The default Page document (``Symfony\Cmf\Bundle\SimpleCmsBundle\Doctrine\Phpcr\Page``)
 is relatively simple, shipping with a handful of the most common properties
 for building a typical page: title, body, tags, publish dates etc.

--- a/bundles/simple_cms/index.rst
+++ b/bundles/simple_cms/index.rst
@@ -1,6 +1,8 @@
 SimpleCmsBundle
 ===============
 
+.. include:: ../_partials/unmaintained.rst.inc
+
 .. toctree::
     :maxdepth: 2
 

--- a/bundles/simple_cms/introduction.rst
+++ b/bundles/simple_cms/introduction.rst
@@ -8,6 +8,8 @@ SimpleCmsBundle
     The SimpleCmsBundle provides a simplistic CMS on top of the CMF components
     and bundles.
 
+.. include:: ../_partials/unmaintained.rst.inc
+
 While the core CMF components focus on flexibility, the simple CMS trades away
 some of that flexibility in favor of simplicity.
 

--- a/bundles/simple_cms/menus.rst
+++ b/bundles/simple_cms/menus.rst
@@ -4,6 +4,8 @@
 Menus
 -----
 
+.. include:: ../_partials/unmaintained.rst.inc
+
 You can use `Knp Menu Bundle`_ to render a menu of your SimpleCms pages. The default Page document
 (``Symfony\Cmf\Bundle\SimpleCmsBundle\Doctrine\Phpcr\Page``) implements the ``Knp\Menu\NodeInterface``
 which allows for rendering them as a menu.

--- a/bundles/simple_cms/multilang.rst
+++ b/bundles/simple_cms/multilang.rst
@@ -4,6 +4,8 @@
 Multi-Language Support
 ----------------------
 
+.. include:: ../_partials/unmaintained.rst.inc
+
 Setting the option ``add_locale_pattern`` to ``true`` in a
 ``Symfony\Cmf\Bundle\SimpleCmsBundle\Doctrine\Phpcr\Page`` document will
 result in prefixing the associated route with ``/{_locale}``. Using the native

--- a/bundles/simple_cms/rendering.rst
+++ b/bundles/simple_cms/rendering.rst
@@ -4,6 +4,8 @@
 Rendering
 ---------
 
+.. include:: ../_partials/unmaintained.rst.inc
+
 You can configure a mapping of document class to template and/or controller
 by configuring the :ref:`RoutingBundle <reference-config-routing-dynamic>`.
 When you need specific settings for a single page, you can call


### PR DESCRIPTION
fix #792 

* do you agree with the wording?
* did i pick the right bundles, or is there others i missed / some that we consider still maintained? note that https://github.com/symfony-cmf/blog-bundle is not mentioned at all in the cmf docs, so imo we don't need to start mentioning it.

i remember proposing to also unmaintain the block bundle, but that did not get consensous...