### PR TITLE
render() is a Twig function, not a block

### DIFF
--- a/bundles/create/introduction.rst
+++ b/bundles/create/introduction.rst
@@ -368,7 +368,7 @@ higher, the method reads:
 
     .. code-block:: jinja
 
-        {% render(controller("cmf_create.jsloader.controller:includeJSFilesAction")) %}
+        {{ render(controller("cmf_create.jsloader.controller:includeJSFilesAction")) }}
 
     .. code-block:: php
 


### PR DESCRIPTION
Correct a typo which cause a Twig exception because the _render_ block is called but it doesn't exist.