### PR TITLE
Updated the way fixtures should be loaded

### DIFF
--- a/tutorial/make-homepage.rst
+++ b/tutorial/make-homepage.rst
@@ -197,8 +197,9 @@ Now:
 Now empty your repository, reinitialize it and reload your fixtures:
 
 .. code-block:: bash
-
-    $ php bin/console doctrine:phpcr:fixtures:load --append
+    $ php bin/console doctrine:phpcr:node:remove /cms
+    $ php bin/console doctrine:phpcr:repository:init
+    $ php bin/console doctrine:phpcr:fixtures:load
 
 and verify that the ``cms`` node has been created correctly, using the
 ``doctrine:phpcr:node:dump`` command with the ``props`` flag:

--- a/tutorial/make-homepage.rst
+++ b/tutorial/make-homepage.rst
@@ -198,7 +198,7 @@ Now empty your repository, reinitialize it and reload your fixtures:
 
 .. code-block:: bash
 
-    $ php bin/console doctrine:phpcr:fixtures:load
+    $ php bin/console doctrine:phpcr:fixtures:load --append
 
 and verify that the ``cms`` node has been created correctly, using the
 ``doctrine:phpcr:node:dump`` command with the ``props`` flag:

--- a/tutorial/make-homepage.rst
+++ b/tutorial/make-homepage.rst
@@ -197,6 +197,7 @@ Now:
 Now empty your repository, reinitialize it and reload your fixtures:
 
 .. code-block:: bash
+
     $ php bin/console doctrine:phpcr:node:remove /cms
     $ php bin/console doctrine:phpcr:repository:init
     $ php bin/console doctrine:phpcr:fixtures:load


### PR DESCRIPTION
While i was following the tutorial i noticed that when i was running php bin\console doctrine:phpcr:fixtures:load it hit me with errors. The only way i managed loading the fixtures was by using --append ( found the solution somewhere on google groups )