### PR TITLE
Changed paths from bin/console to app/console

### DIFF
--- a/cookbook/editions/cmf_sandbox.rst
+++ b/cookbook/editions/cmf_sandbox.rst
@@ -115,7 +115,7 @@ run:
 
 .. code-block:: bash
 
-    $ php bin/console doctrine:database:create
+    $ php app/console doctrine:database:create
 
 If you don't have sqlite, you can specify ``pdo_mysql`` or ``pdo_pgsql`` and
 provide the database name and login credentials to use.
@@ -124,14 +124,14 @@ Then you have to set up your database with:
 
 .. code-block:: bash
 
-    $ php bin/console doctrine:phpcr:init:dbal
+    $ php app/console doctrine:phpcr:init:dbal --force
 
 Once your database is set up, you need to `register the node types`_ for
 phpcr-odm:
 
 .. code-block:: bash
 
-    $ php bin/console doctrine:phpcr:repository:init
+    $ php app/console doctrine:phpcr:repository:init
 
 Import the Fixtures
 ~~~~~~~~~~~~~~~~~~~
@@ -141,7 +141,7 @@ They are loaded using the fixture loading concept of PHPCR-ODM.
 
 .. code-block:: bash
 
-    $ php bin/console -v doctrine:phpcr:fixtures:load
+    $ php app/console -v doctrine:phpcr:fixtures:load
 
 This command loads fixtures from all bundles that provide them in the
 ``DataFixtures/PHPCR`` folder. The sandbox has fixtures in the


### PR DESCRIPTION
The bin/console does not exist after running the above getting started commands so it is changed to app/console. Also added --force to `php app/console doctrine:phpcr:init:dbal --force` because of the notice you get otherwise: `ATTENTION: This operation should not be executed in a production environment. Please use "--force" to execute the command.`