### PR TITLE
stick with ubuntu precise for now to avoid spelling complaints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+# different spelling rules on trusty, stick with precise for now
+dist: precise
 
 python: 2.7
 


### PR DESCRIPTION
seems that the buid is failing because travis started using trusty and it has a different default dictionary. just fixing to precise until somebody wants to go through and add words to our dictionary.