### PR TITLE
update links, fix wording from Symfony2 to Symfony

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,13 @@
 Contributing
 ------------
 
-Symfony2 CMF is an open source, community-driven project. We follow the same
-guidelines as core Symfony2. If you'd like to contribute, please read the
+Symfony CMF is an open source, community-driven project. We follow the same
+guidelines as core Symfony. If you'd like to contribute, please read the
 [Contributing Documentation][1] part of the documentation. If you're submitting a pull
-request, please make yourself comfortable with [the format][2], follow the
-guidelines in the [Creating a Pull Request][3] section and use the [Pull Request
-Format][4].
-
-> :warning: **NOTE**
-> If you are documenting new features you should base your PR on the
-> **dev branch**, *not* the master branch.
+request, please make yourself comfortable with [the documentation format][2].
+The [Symfony documentation guide][3] can be helpful for you - just replace the
+repository names in the examples.
 
  [1]: https://symfony.com/doc/current/contributing/documentation/index.html
  [2]: https://symfony.com/doc/current/contributing/documentation/format.html
- [3]: https://symfony.com/doc/current/contributing/documentation/overview.html#creating-a-pull-request
- [4]: https://symfony.com/doc/current/contributing/documentation/overview.html#pull-request-format
+ [3]: https://symfony.com/doc/current/contributing/documentation/overview.html

--- a/bundles/block/cache.rst
+++ b/bundles/block/cache.rst
@@ -257,7 +257,7 @@ When using the Esi, Ssi or Js cache adapters, the settings passed here are remem
     .. code-block:: jinja
 
         {{ sonata_block_render({ 'name': 'rssBlock' }, {
-            'title': 'Symfony2 CMF news',
+            'title': 'Symfony CMF news',
             'url': 'http://cmf.symfony.com/news.rss',
             'maxItems': 2
         }) }}
@@ -267,7 +267,7 @@ When using the Esi, Ssi or Js cache adapters, the settings passed here are remem
         <?php echo $view['blocks']->render(array(
             'name' => 'rssBlock',
         ), array(
-            'title'    => 'Symfony2 CMF news',
+            'title'    => 'Symfony CMF news',
             'url'      => 'http://cmf.symfony.com/news.rss',
             'maxItems' => 2,
         )) ?>

--- a/bundles/block/create_your_own_blocks.rst
+++ b/bundles/block/create_your_own_blocks.rst
@@ -236,14 +236,14 @@ Example of how settings can be overwritten through a template helper:
     .. code-block:: jinja
 
         {{ sonata_block_render({'name': 'rssBlock'}, {
-            'title': 'Symfony2 CMF news',
+            'title': 'Symfony CMF news',
             'url': 'http://cmf.symfony.com/news.rss'
         }) }}
 
     .. code-block:: html+php
 
         <?php $view['blocks']->render(array('name' => 'rssBlock'), array(
-            'title' => 'Symfony2 CMF news',
+            'title' => 'Symfony CMF news',
             'url'   => 'http://cmf.symfony.com/news.rss',
         )) ?>
 

--- a/bundles/block/types.rst
+++ b/bundles/block/types.rst
@@ -123,7 +123,7 @@ Create a document::
     $myRssBlock = new RssBlock();
     $myRssBlock->setParentDocument($parentPage);
     $myRssBlock->setName('rssBlock');
-    $myRssBlock->setSetting('title', 'Symfony2 CMF news');
+    $myRssBlock->setSetting('title', 'Symfony CMF news');
     $myRssBlock->setSetting('url', 'http://cmf.symfony.com/news.rss');
     $myRssBlock->setSetting('maxItems', 3);
 

--- a/bundles/content/exposing_content_via_rest.rst
+++ b/bundles/content/exposing_content_via_rest.rst
@@ -146,7 +146,7 @@ for details.
 
 .. _`FOSRestBundle`: https://github.com/FriendsOfSymfony/FOSRestBundle
 .. _`JMSSerializerBundle`: https://github.com/schmittjoh/JMSSerializerBundle
-.. _`FOSRestBundle view layer`: https://symfony.com/doc/master/bundles/FOSRestBundle/2-the-view-layer.html
+.. _`FOSRestBundle view layer`: https://symfony.com/doc/current/bundles/FOSRestBundle/2-the-view-layer.html
 .. _Composer: https://getcomposer.org/
 .. _`documentation of the JMS serializer`: http://jmsyst.com/libs/#serializer
 .. _`default response format changed between 1.0 and 1.1 of the ContentBundle`: https://github.com/symfony-cmf/content-bundle/pull/91

--- a/bundles/core/publish_workflow.rst
+++ b/bundles/core/publish_workflow.rst
@@ -5,9 +5,9 @@ Publish Workflow
 ----------------
 
 The publish workflow system allows to control what content is available on the
-site. This is similar to the `Symfony2 Security component`_. But contrary to the
+site. This is similar to the `Symfony Security component`_. But contrary to the
 security context, the publish check can be executed even when no firewall is in
-place and the security context thus has no token (see `Symfony2 Authorization`_).
+place and the security context thus has no token (see `Symfony Authorization`_).
 
 The publish workflow is also tied into the security workflow: The CoreBundle
 registers a security voter that forwards security checks to the publish
@@ -371,6 +371,6 @@ There is a :doc:`Sonata admin extension <../sonata_phpcr_admin_integration/core>
 available to edit workflow information on any document implementing the
 interface.
 
-.. _`Symfony2 security component`: http://symfony.com/doc/current/components/security.html
-.. _`Symfony2 Authorization`: http://symfony.com/doc/current/components/security/authorization.html
+.. _`Symfony security component`: http://symfony.com/doc/current/components/security.html
+.. _`Symfony Authorization`: http://symfony.com/doc/current/components/security/authorization.html
 .. _`ACL checks`: http://symfony.com/doc/current/security/acl.html

--- a/bundles/create/introduction.rst
+++ b/bundles/create/introduction.rst
@@ -7,7 +7,7 @@ CreateBundle
 
     The CreateBundle provides modern front-end in-place editing for web
     applications. It integrates create.js and the CreatePHP library into
-    Symfony2.
+    Symfony.
 
 .. include:: ../_partials/unmaintained.rst.inc
 
@@ -307,7 +307,7 @@ JavaScript loader check if the current user is granted the configured
 .. tip::
 
     In order to have security in place, you need to configure a
-    "Symfony2 firewall". Read more in the `Symfony2 security chapter`_.
+    "Symfony firewall". Read more in the `Symfony security chapter`_.
     If you do not do that, create.js will not be loaded and editing
     will be disabled.
 
@@ -363,8 +363,7 @@ after those to be able to customize as needed) with:
     Make sure Assetic is rewriting the paths in your CSS files properly or you
     might not see icon images.
 
-In your page bottom area, load the JavaScript files. If you are using Symfony 2.2 or
-higher, the method reads:
+In your page bottom area, load the JavaScript files:
 
 .. configuration-block::
 
@@ -666,4 +665,4 @@ Read On
 .. _`symfony-cmf/create-bundle`: https://packagist.org/packages/symfony-cmf/create-bundle
 .. _`RDF`: https://en.wikipedia.org/wiki/Resource_Description_Framework
 .. _`RDFa`: https://en.wikipedia.org/wiki/RDFa
-.. _`Symfony2 security chapter`: https://symfony.com/doc/current/book/security.html
+.. _`Symfony security chapter`: https://symfony.com/doc/current/security.html

--- a/bundles/menu/introduction.rst
+++ b/bundles/menu/introduction.rst
@@ -180,5 +180,5 @@ Read On
 .. _`KnpMenu`: https://github.com/knplabs/KnpMenu
 .. _`KnpMenuBundle`: https://github.com/knplabs/KnpMenuBundle
 .. _`with composer`: https://getcomposer.org
-.. _`rendering menus`: https://symfony.com/doc/master/bundles/KnpMenuBundle/index.html#rendering-menus
+.. _`rendering menus`: https://symfony.com/doc/current/bundles/KnpMenuBundle/index.html#rendering-menus
 .. _`symfony-cmf/menu-bundle`: https://packagist.org/packages/symfony-cmf/menu-bundle

--- a/bundles/menu/menu_documents.rst
+++ b/bundles/menu/menu_documents.rst
@@ -123,4 +123,4 @@ The standard menu node implements ``PublishTimePeriodInterface`` and
 The ``MenuContentVoter`` decides that a menu node is not published if the
 content it is pointing to is not published.
 
-.. _`Creating Menus: The Basics`: https://github.com/KnpLabs/KnpMenu/blob/1.1.x/doc/01-Basic-Menus.markdown
+.. _`Creating Menus: The Basics`: https://github.com/KnpLabs/KnpMenu/blob/master/doc/01-Basic-Menus.markdown

--- a/bundles/menu/menu_provider.rst
+++ b/bundles/menu/menu_provider.rst
@@ -33,4 +33,4 @@ are not located under the menu basepath.
     You can also write your completely custom provider and register it with the
     KnpMenu as explained in the `KnpMenuBundle custom provider documentation`_.
 
-.. _`KnpMenuBundle custom provider documentation`: https://symfony.com/doc/master/bundles/KnpMenuBundle/custom_provider.html
+.. _`KnpMenuBundle custom provider documentation`: https://symfony.com/doc/current/bundles/KnpMenuBundle/custom_provider.html

--- a/bundles/phpcr_odm/configuration.rst
+++ b/bundles/phpcr_odm/configuration.rst
@@ -353,7 +353,7 @@ supported by Doctrine.
 
 Specify the Doctrine DBAL connection name to use if you don't want to use the
 default connection. The name must be one of the names of the ``doctrine.dbal``
-section of your Doctrine configuration, see the `Symfony2 Doctrine documentation`_.
+section of your Doctrine configuration, see the `Symfony Doctrine documentation`_.
 
 ``jackalope.disable_transactions``
 """"""""""""""""""""""""""""""""""
@@ -372,7 +372,7 @@ Logging and Profiling
 ~~~~~~~~~~~~~~~~~~~~~
 
 When using any of the Jackalope PHPCR implementations, you can activate logging
-to log to the symfony log, or profiling to show information in the Symfony2
+to log to the symfony log, or profiling to show information in the Symfony
 debug toolbar:
 
 .. configuration-block::
@@ -659,7 +659,7 @@ Absolute path to the jackrabbit jar file. If this is set, you can use the
 
 For tuning the output of the ``doctrine:phpcr:dump`` command.
 
-.. _`Symfony2 Doctrine documentation`: https://symfony.com/doc/current/book/doctrine.html
+.. _`Symfony Doctrine documentation`: https://symfony.com/doc/current/doctrine.html
 .. _`last modified listener cookbook entry`: http://docs.doctrine-project.org/projects/doctrine-phpcr-odm/en/latest/cookbook/last-modified.html
 .. _`Doctrine ORM`: https://symfony.com/doc/current/reference/configuration/doctrine.html#caching-drivers
 .. _`curl-setopt`: http://php.net/manual/de/function.curl-setopt.php

--- a/bundles/phpcr_odm/events.rst
+++ b/bundles/phpcr_odm/events.rst
@@ -96,6 +96,6 @@ You can find more information and examples of the doctrine event system
 in "`How to Register Event Listeners and Subscribers`_" of the core documentation.
 
 .. _`Doctrine PHPCR-ODM event system documentation`: http://docs.doctrine-project.org/projects/doctrine-phpcr-odm/en/latest/reference/events.html
-.. _`Symfony event subscriber`: https://symfony.com/doc/master/components/event_dispatcher/introduction.html#using-event-subscribers
-.. _`Doctrine ORM events`: https://symfony.com/doc/current/cookbook/doctrine/event_listeners_subscribers.html
-.. _`How to Register Event Listeners and Subscribers`: https://symfony.com/doc/current/cookbook/doctrine/event_listeners_subscribers.html
+.. _`Symfony event subscriber`: https://symfony.com/doc/current/components/event_dispatcher/introduction.html#using-event-subscribers
+.. _`Doctrine ORM events`: https://symfony.com/doc/current/doctrine/event_listeners_subscribers.html
+.. _`How to Register Event Listeners and Subscribers`: https://symfony.com/doc/current/doctrine/event_listeners_subscribers.html

--- a/bundles/phpcr_odm/fixtures_initializers.rst
+++ b/bundles/phpcr_odm/fixtures_initializers.rst
@@ -283,7 +283,7 @@ Fixture Loading
 
 To use the ``doctrine:phpcr:fixtures:load`` command, you additionally need to
 install the `DoctrineFixturesBundle`_ which brings the
-`Doctrine data-fixtures`_ into Symfony2.
+`Doctrine data-fixtures`_ into Symfony.
 
 Fixtures work the same way they work for Doctrine ORM. You write fixture
 classes implementing ``Doctrine\Common\DataFixtures\FixtureInterface``. If you

--- a/bundles/phpcr_odm/forms.rst
+++ b/bundles/phpcr_odm/forms.rst
@@ -101,8 +101,7 @@ The minimal code required to use this type looks as follows::
 
     When building an admin interface with the SonataDoctrinePHPCRAdminBundle_
     there is also the ``sonata_type_model``, which is more powerful, allowing to
-    add to the referenced documents on the fly. Unfortunately it is
-    `currently broken`_.
+    add to the referenced documents on the fly.
 
 phpcr_reference
 ~~~~~~~~~~~~~~~
@@ -186,4 +185,3 @@ correct.
 .. _BurgovKeyValueFormBundle: https://github.com/Burgov/KeyValueFormBundle
 .. _`Symfony documentation on the entity form type`: https://symfony.com/doc/current/reference/forms/types/entity.html
 .. _SonataDoctrinePHPCRAdminBundle: https://sonata-project.org/bundles/doctrine-phpcr-admin/master/doc/index.html
-.. _`currently broken`: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/145

--- a/bundles/phpcr_odm/introduction.rst
+++ b/bundles/phpcr_odm/introduction.rst
@@ -24,7 +24,7 @@ Out of the box, this bundle supports the following PHPCR implementations:
 
 .. tip::
 
-    This reference only explains the Symfony2 integration of PHPCR and
+    This reference only explains the Symfony integration of PHPCR and
     PHPCR-ODM. To learn how to use PHPCR, refer to `the PHPCR website`_ and
     for Doctrine PHPCR-ODM to the `PHPCR-ODM documentation`_.
 
@@ -96,7 +96,7 @@ DBAL. The full documentation is in the :doc:`configuration reference <configurat
 
 To use Jackalope Doctrine DBAL, you need to configure a database connection
 with the DoctrineBundle. For detailed information, see the
-`Symfony2 Doctrine documentation`_. A simple example is:
+`Symfony Doctrine documentation`_. A simple example is:
 
 .. code-block:: yaml
 
@@ -346,7 +346,7 @@ Profiling and Performance of Jackalope
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When using any of the Jackalope PHPCR implementations, you can activate logging
-to log to the symfony log, or profiling to show information in the Symfony2
+to log to the symfony log, or profiling to show information in the Symfony
 debug toolbar:
 
 .. configuration-block::
@@ -526,25 +526,14 @@ Read On
 
 .. _`Doctrine PHPCR-ODM`: http://docs.doctrine-project.org/projects/doctrine-phpcr-odm/en/latest/index.html
 .. _`DoctrinePHPCRBundle`: https://github.com/doctrine/DoctrinePHPCRBundle
-.. _`Symfony2 Doctrine documentation`: https://symfony.com/doc/current/book/doctrine.html
+.. _`Symfony Doctrine documentation`: https://symfony.com/doc/current/doctrine.html
 .. _`Jackalope`: http://jackalope.github.io/
 .. _`the PHPCR website`: http://phpcr.github.io/
 .. _`PHPCR-ODM documentation`: http://docs.doctrine-project.org/projects/doctrine-phpcr-odm/en/latest/
 .. _`bug in libxml`: https://bugs.php.net/bug.php?id=36501
 .. _`with composer`: https://getcomposer.org
 .. _`doctrine/phpcr-bundle`: https://packagist.org/packages/doctrine/phpcr-bundle
-.. _`metadata caching`: https://symfony.com/doc/master/reference/configuration/doctrine.html
-.. _`PHPCR-ODM documentation on Multilanguage`: http://docs.doctrine-project.org/projects/doctrine-phpcr-odm/en/latest/reference/multilang.html
 .. _`custom node type`: https://github.com/doctrine/phpcr-odm/wiki/Custom-node-type-phpcr%3Amanaged
-.. _`the PHPCR-ODM documentation`: http://docs.doctrine-project.org/projects/doctrine-phpcr-odm/en/latest/reference/events.html
-.. _`Symfony event subscriber`: https://symfony.com/doc/master/components/event_dispatcher/introduction.html#using-event-subscribers
-.. _`Symfony cookbook entry`: https://symfony.com/doc/current/cookbook/doctrine/event_listeners_subscribers.html
-.. _`Symfony documentation on the entity form type`: https://symfony.com/doc/current/reference/forms/types/entity.html
-.. _SonataDoctrinePHPCRAdminBundle: https://sonata-project.org/bundles/doctrine-phpcr-admin/master/doc/index.html
-.. _`currently broken`: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/145
 .. _`DoctrineMigrationsBundle`: https://symfony.com/doc/current/bundles/DoctrineMigrationsBundle/index.html
 .. _`DoctrineFixturesBundle`: https://symfony.com/doc/current/bundles/DoctrineFixturesBundle/index.html
-.. _`Doctrine data-fixtures`: https://github.com/doctrine/data-fixtures
-.. _`documentation of the DoctrineFixturesBundle`: https://symfony.com/doc/current/bundles/DoctrineFixturesBundle/index.html
 .. _`SQL2 queries`: http://www.h2database.com/jcr/grammar.html
-.. _`BurgovKeyValueFormBundle`: https://github.com/Burgov/KeyValueFormBundle

--- a/bundles/phpcr_odm/models.rst
+++ b/bundles/phpcr_odm/models.rst
@@ -350,9 +350,9 @@ objects go through their persistence lifecycle.
 
 .. _`PHP Content Repository`: http://phpcr.github.io/
 .. _`JSR-283 specification`: https://jcp.org/en/jsr/detail?id=283
-.. _`Doctrine ORM`: https://symfony.com/doc/current/book/doctrine.html
+.. _`Doctrine ORM`: https://symfony.com/doc/current/doctrine.html
 .. _`doctrine documentation`: http://docs.doctrine-project.org/projects/doctrine-phpcr-odm/en/latest/reference/basic-mapping.html#basicmapping-identifier-generation-strategies
 .. _`Basic Mapping Documentation`: http://docs.doctrine-project.org/projects/doctrine-phpcr-odm/en/latest/reference/basic-mapping.html
 .. _`the QueryBuilder documentation`: http://docs.doctrine-project.org/projects/doctrine-phpcr-odm/en/latest/reference/query-builder.html
 .. _`create complex queries`: http://docs.doctrine-project.org/projects/doctrine-phpcr-odm/en/latest/reference/query-builder.html
-.. _`Custom Repository Classes`: https://symfony.com/doc/current/book/doctrine.html#custom-repository-classes
+.. _`Custom Repository Classes`: https://symfony.com/doc/current/doctrine/repository.html

--- a/bundles/routing/dynamic.rst
+++ b/bundles/routing/dynamic.rst
@@ -667,5 +667,5 @@ Read on in the chapter :doc:`customizing the dynamic router <dynamic_customize>`
 .. _`CMF Routing component`: https://github.com/symfony-cmf/Routing
 .. _`Doctrine ORM`: http://www.doctrine-project.org/projects/orm.html
 .. _`PHPCR-ODM`: http://www.doctrine-project.org/projects/phpcr-odm.html
-.. _`URL generating capabilities of Symfony`: https://symfony.com/doc/current/book/routing.html#generating-urls
+.. _`URL generating capabilities of Symfony`: https://symfony.com/doc/current/routing.html#generating-urls
 .. _`FOSJsRoutingBundle`: https://github.com/FriendsOfSymfony/FOSJsRoutingBundle

--- a/bundles/routing/dynamic_customize.rst
+++ b/bundles/routing/dynamic_customize.rst
@@ -264,5 +264,5 @@ will check that they exist.
 You can override the validator by setting the
 ``cmf_routing.validator.route_defaults.class`` parameter.
 
-.. _`Creating and configuring services in the container`: https://symfony.com/doc/current/book/service_container.html#creating-configuring-services-in-the-container
+.. _`Creating and configuring services in the container`: https://symfony.com/doc/current/service_container.html#creating-configuring-services-in-the-container
 .. _`PHPCR-ODM`: http://www.doctrine-project.org/projects/phpcr-odm.html

--- a/bundles/routing/introduction.rst
+++ b/bundles/routing/introduction.rst
@@ -108,5 +108,5 @@ For more information on Routing in the Symfony CMF, please refer to:
 .. _`symfony-cmf/routing-bundle`: https://packagist.org/packages/symfony-cmf/routing-bundle
 .. _`RoutingBundle`: https://github.com/symfony-cmf/routing-bundle#readme
 .. _`PHPCR-ODM`: http://www.doctrine-project.org/projects/phpcr-odm.html
-.. _`documentation for DependencyInjection tags`: https://symfony.com/doc/2.1/reference/dic_tags.html
+.. _`documentation for DependencyInjection tags`: https://symfony.com/doc/current/reference/dic_tags.html
 .. _`Routing`: https://symfony.com/doc/current/components/routing/introduction.html

--- a/bundles/search/configuration.rst
+++ b/bundles/search/configuration.rst
@@ -146,11 +146,11 @@ template.
             ),
         ));
 
-.. _`LiipSearchBundle`: https://github.com/liip/LiipSearchBundle
-
 ``max_results``
 """""""""""""""
 
 **type**: ``integer`` **default**: ``null``
 
 Defines a limit for number of results returned.
+
+.. _`LiipSearchBundle`: https://github.com/liip/LiipSearchBundle

--- a/bundles/seo/error_pages.rst
+++ b/bundles/seo/error_pages.rst
@@ -184,4 +184,4 @@ Now, register this new class as a service and tag it as
 
 The tag allows a ``group`` attribute, in order to group suggested links.
 
-.. _Symfony Documentation: https://symfony.com/doc/current/cookbook/controller/error_pages.html#overriding-the-default-exceptioncontroller
+.. _Symfony Documentation: https://symfony.com/doc/current/controller/error_pages.html#overriding-the-default-exceptioncontroller

--- a/bundles/simple_cms/extending_page_class.rst
+++ b/bundles/simple_cms/extending_page_class.rst
@@ -66,7 +66,7 @@ For example::
 
     // set extras
     $extras = array(
-        'subtext' => 'Add CMS functionality to applications built with the Symfony2 PHP framework.',
+        'subtext' => 'Add CMS functionality to applications built with the Symfony PHP framework.',
         'headline-icon' => 'exclamation.png',
     );
 

--- a/components/routing/chain.rst
+++ b/components/routing/chain.rst
@@ -5,7 +5,7 @@ ChainRouter
 ===========
 
 At the core of the Symfony CMF Routing component sits the ``ChainRouter``. It
-is used as a replacement for Symfony2's default routing system.
+is used as a replacement for Symfony's default routing system.
 
 The ``ChainRouter`` works by accepting a set of prioritized routing
 strategies, :class:`Symfony\\Component\\Routing\\RouterInterface`
@@ -31,7 +31,7 @@ Adding Routers to the Chain
 ---------------------------
 
 Routers are added using the ``add`` method of the ``ChainRouter``. Use this to
-add the default Symfony2 router::
+add the default Symfony router::
 
     use Symfony\Component\Routing\Router;
     use Symfony\Cmf\Component\Routing\ChainRouter;
@@ -40,12 +40,12 @@ add the default Symfony2 router::
     $chainRouter->add(new Router(...));
     $chainRouter->match('/foo/bar');
 
-Now, when the ``ChainRouter`` matches a request, it will ask the Symfony2
+Now, when the ``ChainRouter`` matches a request, it will ask the Symfony
 ``Router`` to see if the request matches. If there is no match, it will throw a
 :class:`Symfony\\Component\\Routing\\Exception\\ResourceNotFoundException`.
 
 If you add a new router, for instance the ``DynamicRouter``, it will be
-called after the Symfony2 Router (because that was added first). To control the
+called after the Symfony Router (because that was added first). To control the
 order, you can use the second argument of the ``add`` method to set a priority.
 Higher priorities are sorted first.
 
@@ -69,7 +69,7 @@ Register Routers Compiler Pass
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This component provides a ``RegisterRoutersPass``. If you use the
-`Symfony2 Dependency Injection Component`_, you can use this compiler pass to
+`Symfony Dependency Injection Component`_, you can use this compiler pass to
 register all routers with a specific tag::
 
     use Symfony\Cmf\Component\Routing\DependencyInjection\Compiler\RegisterRoutersPass;
@@ -83,7 +83,7 @@ register all routers with a specific tag::
 
 After adding the passes and configuring the container builder, you continue
 with compiling the container as explained in the
-`Symfony2 DI Component compilation section`_.
+`Symfony DI Component compilation section`_.
 
 You can optionally configure the chain router service name. The compiler pass
 will modify this service definition to register the routers when the chain
@@ -92,7 +92,7 @@ service name is ``cmf_routing.router``.
 
 You can also configure the tag name you want to use with the second argument to
 the compiler pass constructor. If you don't, the default tag is ``router``. If
-you are using the :doc:`Symfony2 CMF RoutingBundle <../../bundles/routing/introduction>`,
+you are using the :doc:`Symfony CMF RoutingBundle <../../bundles/routing/introduction>`,
 this tag is already active with the default name.
 
 Routers
@@ -107,10 +107,10 @@ You can easily create your own routers by implementing
 Routing Component already includes a powerful route matching system that you
 can extend to your needs.
 
-Symfony2 Default Router
-~~~~~~~~~~~~~~~~~~~~~~~
+Symfony Default Router
+~~~~~~~~~~~~~~~~~~~~~~
 
-The Symfony2 routing mechanism is itself a ``RouterInterface`` implementation,
+The Symfony routing mechanism is itself a ``RouterInterface`` implementation,
 which means you can use it as a Router in the ``ChainRouter``. This allows you
 to use the default routing declaration system. Read more about this router in
 the `Routing Component`_ article of the core documentation.
@@ -124,5 +124,5 @@ is faster in taking routing decisions.
 Read on about the dynamic router in the :doc:`next section<dynamic>`.
 
 .. _`Routing Component`: https://symfony.com/doc/current/components/routing/introduction.html
-.. _`Symfony2 Dependency Injection Component`: https://symfony.com/doc/master/components/dependency_injection/index.html
-.. _`Symfony2 DI Component compilation section`: https://symfony.com/doc/current/components/dependency_injection/compilation.html
+.. _`Symfony Dependency Injection Component`: https://symfony.com/doc/current/components/dependency_injection/index.html
+.. _`Symfony DI Component compilation section`: https://symfony.com/doc/current/components/dependency_injection/compilation.html

--- a/components/routing/dynamic.rst
+++ b/components/routing/dynamic.rst
@@ -4,7 +4,7 @@
 Dynamic Router
 ==============
 
-The Symfony2 default Router was developed to handle static Route definitions,
+The Symfony default Router was developed to handle static Route definitions,
 as they are usually declared in configuration files, prior to execution.
 The complete routing configuration is injected in the constructor. It then
 creates a :class:`Symfony\\Component\\Routing\\Matcher\\UrlMatcher` with this
@@ -43,7 +43,7 @@ a URL:
 * **cmf_routing.pre_dynamic_match** (Dispatched at the beginning of the
   ``match`` method)
 * **cmf_routing.pre_dynamic_match_request** (Dispatched at the beginning of the
-  ``matchRequest`` method. In the context of the Symfony2 full stack framework,
+  ``matchRequest`` method. In the context of the Symfony full stack framework,
   only this event will be triggered.)
 * **cmf_routing.pre_dynamic_generate** (Dispatched at the beginning of the
   ``generate`` method)
@@ -118,7 +118,7 @@ Route Enhancer Compiler Pass
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This component provides a ``RegisterRouteEnhancersPass``. If you use the
-`Symfony2 Dependency Injection Component`_, you can use this compiler pass to
+`Symfony Dependency Injection Component`_, you can use this compiler pass to
 register all enhancers having a specific tag with the dynamic router::
 
     use Symfony\Cmf\Component\Routing\DependencyInjection\Compiler\RegisterRouterEnhancersPass;
@@ -132,7 +132,7 @@ register all enhancers having a specific tag with the dynamic router::
 
 After adding the passes and configuring the container builder, you continue
 with compiling the container as explained in the
-`Symfony2 DI Component compilation section`_.
+`Symfony DI Component compilation section`_.
 
 You can optionally configure the dynamic router service name. The compiler pass
 will modify this service definition to register the enhancers when the dynamic
@@ -142,7 +142,7 @@ default service name is ``cmf_routing.dynamic_router``.
 You can also configure the tag name you want to use with the second argument to
 the compiler pass constructor. If you don't, the default tag is
 ``dynamic_router_route_enhancer``. If you are using the
-:doc:`Symfony2 CMF RoutingBundle <../../bundles/routing/introduction>`, this tag is
+:doc:`Symfony CMF RoutingBundle <../../bundles/routing/introduction>`, this tag is
 already active with the default name.
 
 Linking a Route with a Content
@@ -165,7 +165,7 @@ with the route instance and put the provided name into ``_route_name``.
 
 All routes still need to extend the base class
 :class:`Symfony\\Component\\Routing\\Route <Symfony\\Component\\Routing\\Route>`
-from the Symfony2 component.
+from the Symfony component.
 
 Redirections
 ------------
@@ -176,7 +176,7 @@ Router in the chain or to another ``Route`` object.
 
 Notice that the actual redirection logic is not handled by the bundle. You
 should implement your own logic to handle the redirection. For an example of
-implementing that redirection under the full Symfony2 stack, refer to
+implementing that redirection under the full Symfony stack, refer to
 :doc:`the RoutingBundle <../../bundles/routing/introduction>`.
 
 .. _component-routing-generator:
@@ -198,11 +198,11 @@ The generator method looks like this::
 
     public function generate($name, $parameters = array(), $referenceType = self::ABSOLUTE_PATH);
 
-In Symfony2 core, the ``$name`` has to be a string with the configured name
+In Symfony core, the ``$name`` has to be a string with the configured name
 of the route to generate. The CMF routing component adds generators that handle
 alternative semantics of ``$name``.
 
-The ``ProviderBasedGenerator`` extends Symfony2's default
+The ``ProviderBasedGenerator`` extends Symfony's default
 :class:`Symfony\\Component\\Routing\\Generator\\UrlGenerator` (which, in turn,
 implements :class:`Symfony\\Component\\Routing\\Generator\\UrlGeneratorInterface`)
 and - if the name is not already a ``Route`` object - loads the Route from the
@@ -232,5 +232,5 @@ call  with any object they can handle.
 .. _`Event Dispatcher`: https://symfony.com/doc/current/components/event_dispatcher/index.html
 .. _`How to create an Event Listener`: https://symfony.com/doc/current/cookbook/event_dispatcher/event_listener.html
 .. _instanceof: http://php.net/operators.type
-.. _`Symfony2 Dependency Injection Component`: https://symfony.com/doc/master/components/dependency_injection/index.html
-.. _`Symfony2 DI Component compilation section`: https://symfony.com/doc/current/components/dependency_injection/compilation.html
+.. _`Symfony Dependency Injection Component`: https://symfony.com/doc/current/components/dependency_injection/index.html
+.. _`Symfony DI Component compilation section`: https://symfony.com/doc/current/components/dependency_injection/compilation.html

--- a/components/routing/introduction.rst
+++ b/components/routing/introduction.rst
@@ -5,7 +5,7 @@
 Routing
 =======
 
-    The Symfony CMF Routing component extends the Symfony2 core routing
+    The Symfony CMF Routing component extends the Symfony core routing
     component to allow more flexibility. The most important difference is that
     the CMF Routing component can load routing information from a database.
 
@@ -16,8 +16,8 @@ Routing
     :doc:`../../bundles/routing/introduction`. If you want to customize how
     the routing works, please read on in this chapter.
 
-Like the Symfony2 routing component, the CMF routing component does not require
-the full Symfony2 Framework and can be used in standalone projects as well.
+Like the Symfony routing component, the CMF routing component does not require
+the full Symfony Framework and can be used in standalone projects as well.
 
 At the core of the Symfony CMF Routing component is the
 :doc:`ChainRouter <chain>`. The ChainRouter tries to match a request with each
@@ -25,11 +25,11 @@ of its registered routers, ignoring the
 :class:`Symfony\\Component\\Routing\\Exception\\ResourceNotFoundException`
 until all routers got a chance to match. The first match wins - if no router
 matched, the :class:`Symfony\\Component\\Routing\\Exception\\ResourceNotFoundException`
-is thrown. The default Symfony2 router can be added to this chain, so the
+is thrown. The default Symfony router can be added to this chain, so the
 standard routing mechanism can still be used in addition to any custom routing.
 
 Additionally, this component provides the :doc:`DynamicRouter <dynamic>`. This
-router is more configurable and flexible than the Symfony2 core router. It can
+router is more configurable and flexible than the Symfony core router. It can
 be configured to load routes from a database, dynamically add information to
 the routes and also generate URLs from model classes.
 
@@ -37,10 +37,10 @@ The goal of Routing
 -------------------
 
 Routing is the task of a framework to determine, based on the web request, what
-code it has to call and which parameters to apply. The Symfony2 core
+code it has to call and which parameters to apply. The Symfony core
 :class:`Symfony\\Component\\Routing\\Matcher\\RequestMatcherInterface` defines
 that a router must convert a :class:`Symfony\\Component\\HttpFoundation\\Request`
-into an array of routing information. In the full stack Symfony2 framework, the
+into an array of routing information. In the full stack Symfony framework, the
 code to call is defined in the ``_controller`` field of the match parameters.
 The framework is going to call the controller specified, matching eventual
 parameters of that method by name with the other parameters found in the match
@@ -48,11 +48,11 @@ array or in the ``Request`` object attributes field.
 
 .. note::
 
-    For a good introduction to routing in the Symfony2 framework, please read
-    the `Routing chapter of the Symfony2 book`_.
+    For a good introduction to routing in the Symfony framework, please read
+    the `Routing chapter of the Symfony book`_.
 
-    To use this component outside of the Symfony2 framework context, have a
-    look at the core Symfony2 `Routing Component`_ to get a fundamental
+    To use this component outside of the Symfony framework context, have a
+    look at the core Symfony `Routing Component`_ to get a fundamental
     understanding of the component. The CMF Routing Component just extends the
     basic behavior.
 
@@ -64,11 +64,11 @@ You can install this component `with composer`_ using the
 ``symfony-cmf/routing-bundle`` you do not need to specify the component
 separately, it is required automatically.
 
-Symfony2 integration
---------------------
+Symfony integration
+-------------------
 
 As mentioned before, this component was designed to use independently of the
-Symfony2 framework.  However, if you wish to use it as part of your Symfony
+Symfony framework.  However, if you wish to use it as part of your Symfony
 CMF project, an integration bundle is also available. Read more about the
 RoutingBundle in :doc:`../../bundles/routing/introduction` in the bundles
 documentation.
@@ -82,5 +82,5 @@ Sections
 
 .. _`with composer`: http://getcomposer.org
 .. _`symfony-cmf/routing`: https://packagist.org/packages/symfony-cmf/routing
-.. _`Routing chapter of the Symfony2 book`: https://symfony.com/doc/current/book/routing.html
+.. _`Routing chapter of the Symfony book`: https://symfony.com/doc/current/routing.html
 .. _`Routing Component`: https://symfony.com/doc/current/components/routing/introduction.html

--- a/contributing/bundles.rst
+++ b/contributing/bundles.rst
@@ -245,11 +245,11 @@ instructions on how the component should be integrated.
 .. _`README template on wiki`: https://github.com/symfony-cmf/symfony-cmf/wiki/README-Template
 .. _`CHANGELOG template on wiki`: https://github.com/symfony-cmf/symfony-cmf/wiki/Change-log-format
 .. _`suggested bundle best practices`: https://symfony.com/doc/current/cookbook/bundles/best_practices.html
-.. _`Mapping Model Classes`: https://symfony.com/doc/master/cookbook/doctrine/mapping_model_classes.html
-.. _`DI alias of the bundle`: https://symfony.com/doc/current/cookbook/bundles/extension.html#creating-an-extension-class
+.. _`Mapping Model Classes`: https://symfony.com/doc/current/doctrine/mapping_model_classes.html
+.. _`DI alias of the bundle`: https://symfony.com/doc/current/bundles/extension.html#creating-an-extension-class
 .. _`XML in the configuration class`: https://symfony.com/doc/current/components/config/definition.html#normalization
 .. _`XML schema`: https://en.wikipedia.org/wiki/.xsd
-.. _`XLIFF format`: https://symfony.com/doc/current/book/translation.html#basic-translation
+.. _`XLIFF format`: https://symfony.com/doc/current/translation.html#basic-translation
 .. _`CONTRIBUTING file from CoreBundle`: https://github.com/symfony-cmf/core-bundle/blob/master/CONTRIBUTING.md
 .. _`LICENSE template on wiki`: https://github.com/symfony-cmf/symfony-cmf/wiki/LICENSE-Template
 .. _`service naming conventions`: https://symfony.com/doc/current/contributing/code/standards.html#service-naming-conventions

--- a/contributing/code.rst
+++ b/contributing/code.rst
@@ -1,8 +1,8 @@
 Contributing
 ============
 
-The Symfony2 CMF team follows all the rules and guidelines of the core
-Symfony2 `development process`_.
+The Symfony CMF team follows all the rules and guidelines of the core
+Symfony `development process`_.
 
 When creating Pull Requests, please follow the Symfony `Submitting a Patch`_
 guidelines.
@@ -19,7 +19,7 @@ Resources / Links
 * `Website`_
 * `Wiki`_
 * `Issue Tracker`_
-* `IRC channel`_
+* `Slack #symfony-cmf channel`_
 * `Users mailing list`_
 * `Devs mailing list`_
 
@@ -28,7 +28,7 @@ Resources / Links
 .. _`Website`: http://cmf.symfony.com/
 .. _`Wiki`: https://github.com/symfony-cmf/symfony-cmf/wiki
 .. _`Issue Tracker`: https://github.com/symfony-cmf/symfony-cmf/issues
-.. _`IRC channel`: http://webchat.freenode.net/?channels=%23symfony-cmf
+.. _`Slack #symfony-cmf channel`: https://slackinvite.me/to/symfony-devs
 .. _`Users mailing list`: https://groups.google.com/forum/#!forum/symfony-cmf-users
 .. _`Devs mailing list`: https://groups.google.com/forum/#!forum/symfony-cmf-devs
 .. _`Submitting a Patch`: https://symfony.com/doc/current/contributing/code/patches.html

--- a/contributing/license.rst
+++ b/contributing/license.rst
@@ -1,13 +1,13 @@
 Licensing
 =========
 
-The Symfony2 CMF aims to provide liberal open source licenses for its entire stack.
+The Symfony CMF aims to provide liberal open source licenses for its entire stack.
 
 Code
 ----
 
 The code stack is covered by the `Apache license`_ for Jackalope and PHPCR,
-the rest of the stack, notably the Symfony2 code, PHPCR-ODM, create.js and
+the rest of the stack, notably the Symfony code, PHPCR-ODM, create.js and
 Hallo.js are `MIT licensed`_. Please refer to the relevant LICENSE files in
 the given source packages.
 

--- a/contributing/releases.rst
+++ b/contributing/releases.rst
@@ -23,13 +23,6 @@ and master becomes aliased to 1.1.x-dev.
 The CMF Standard Edition and symfony-cmf will get point releases whenever one
 of the included bundles does a point release.
 
-.. note::
-
-    The CMF is quite new. As with Symfony 2.0, we don't want to promise BC
-    at all cost yet. If reasonably doable, we will keep the code BC or use
-    deprecations, but there might be exceptions where BC is too cumbersome.
-    The ``UPGRADE.md`` document will help you in those cases.
-
 Development
 -----------
 
@@ -55,15 +48,13 @@ and maintenance contracts.
 Backward Compatibility
 ----------------------
 
-For the next releases, we will maintain BC if possible. If something needs to
-be broken, the UPGRADE.md file will help you to update the project. We will
-switch to a BC-at-all-cost model later, once the CMF has stabilized and
-matured.
+We make an effort to respect semver_. When possible, we will provide backward
+compatible (BC) minor versions. When this would be too cumbersome, we will
+bump to a new major version. Major versions do not necessarily follow the
+Symfony framework major versions.
 
-.. note::
-
-    The work on Symfony CMF 2.0 will start whenever enough major features breaking
-    backward compatibility are waiting on the todo-list.
+The ``UPGRADE.md`` document will help you to both upgrade minor and major
+versions.
 
 Deprecations
 ------------
@@ -80,6 +71,7 @@ Rationale
 This release process was adopted to give more *predictability* and
 *transparency*. It is heavily inspired by the `core Symfony release process`_.
 
+.. _semver: http://semver.org/
 .. _Git repository: https://github.com/symfony/symfony
 .. _SensioLabs: http://sensiolabs.com/
 .. _core Symfony release process: https://symfony.com/doc/current/contributing/community/releases.html

--- a/cookbook/database/choosing_storage_layer.rst
+++ b/cookbook/database/choosing_storage_layer.rst
@@ -177,7 +177,7 @@ only bound to the PHPCR interfaces.
 Please see :doc:`choosing_phpcr_implementation` for more details
 on the available PHPCR implementations and their requirements and
 :doc:`../../bundles/phpcr_odm/introduction` for how to configure a repository
-in Symfony2.
+in Symfony.
 
 PHPCR ODM
 ---------

--- a/cookbook/editions/cmf_core.rst
+++ b/cookbook/editions/cmf_core.rst
@@ -18,7 +18,7 @@ instructions on how to install a demonstration sandbox.
 Preconditions
 -------------
 
-* `Installation of Symfony2`_
+* `Installation of Symfony`_
 * :doc:`../../bundles/phpcr_odm/introduction`
 
 Installation
@@ -154,4 +154,4 @@ If you want to support multiple languages, have a look at
 Then have a look at the individual :doc:`bundles <../../bundles/index>` you are
 interested in.
 
-.. _`Installation of Symfony2`: https://symfony.com/doc/current/book/installation.html
+.. _`Installation of Symfony`: https://symfony.com/doc/current/setup.html

--- a/cookbook/editions/cmf_sandbox.rst
+++ b/cookbook/editions/cmf_sandbox.rst
@@ -25,8 +25,8 @@ the details).
 Requirements
 ------------
 
-As Symfony CMF Sandbox is based on Symfony2, you should make sure you meet the
-`Requirements for running Symfony2`_. `Git 1.6+`_. The ``php-intl`` extension is
+As Symfony CMF Sandbox is based on Symfony, you should make sure you meet the
+`Requirements for running Symfony`_. `Git 1.6+`_. The ``php-intl`` extension is
 also needed to follow the installation steps listed below.
 
 Installation
@@ -165,6 +165,6 @@ doctrine proxies and dump the Assetic assets:
 .. _`Symfony CMF Standard Edition`: https://github.com/symfony-cmf/standard-edition/
 .. _`Composer`: https://getcomposer.org
 .. _`CMF sandbox github repository`: https://github.com/symfony-cmf/cmf-sandbox
-.. _`Requirements for running Symfony2`: https://symfony.com/doc/current/reference/requirements.html
+.. _`Requirements for running Symfony`: https://symfony.com/doc/current/reference/requirements.html
 .. _`Git 1.6+`: https://git-scm.com/
 .. _`register the node types`: https://github.com/doctrine/phpcr-odm/wiki/Custom-node-type-phpcr%3Amanaged

--- a/index.rst
+++ b/index.rst
@@ -1,7 +1,7 @@
 Symfony CMF Documentation
 =========================
 
-The Symfony2 Content Management Framework (CMF) project is organized by the Symfony
+The Symfony Content Management Framework (CMF) project is organized by the Symfony
 community and has several sponsoring companies and prominent open source leaders
 implementing the philosophy of the `decoupled CMS`_.
 
@@ -81,7 +81,7 @@ Do you want to contribute to the Symfony CMF? Start reading these articles!
 :doc:`Browse the contributing guide <contributing/index>`
 
 .. _`decoupled CMS`: http://decoupledcms.org
-.. _`Symfony2`: https://symfony.com
+.. _`Symfony`: https://symfony.com
 .. _`Documentation planning`: https://github.com/symfony-cmf/symfony-cmf/wiki/Documentation-Planning
 .. _`Symfony Content Management Framework`: http://cmf.symfony.com
 .. _`documentation is hosted on github`: https://github.com/symfony-cmf/symfony-cmf-docs

--- a/quick_tour/the_third_party_bundles.rst
+++ b/quick_tour/the_third_party_bundles.rst
@@ -237,7 +237,7 @@ You made it! Let's summarize what you've learned in the Quick Tour:
 * Instead of binding controllers to routes, the routes are bound to content
   objects.
 * The Symfony CMF took care not to reinvent the wheel. That resulted in a lot
-  of bundles integrating commonly known Symfony2 bundles.
+  of bundles integrating commonly known Symfony bundles.
 
 I can't tell you more about the architecture and bundles of the Symfony CMF,
 but there is much much more to explore. Take a look at

--- a/tutorial/auto-routing.rst
+++ b/tutorial/auto-routing.rst
@@ -55,7 +55,7 @@ Enable the Dynamic Router
 
 The RoutingAutoBundle uses the CMF `RoutingBundle`_ which enables routes to
 be provided from a database (in addition to being provided from
-the routing configuration files as in core Symfony 2).
+the routing configuration files as in core Symfony).
 
 Add the following to your application configuration:
 
@@ -246,6 +246,6 @@ Have a look at what you have:
 
 The routes have been automatically created!
 
-.. _`routingautobundle documentation`: https://symfony.com/doc/current/cmf/bundles/routing_auto.html
+.. _`routingautobundle documentation`: https://symfony.com/doc/master/cmf/bundles/routing_auto.html
 .. _`SonataDoctrinePhpcrAdminBundle`: https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle
 .. _`routingbundle`: https://symfony.com/doc/master/cmf/bundles/routing/index.html

--- a/tutorial/introduction.rst
+++ b/tutorial/introduction.rst
@@ -15,7 +15,7 @@ using the following bundles:
 
 It is assumed that you have:
 
-* A working knowledge of the Symfony 2 framework;
+* A working knowledge of the Symfony framework;
 * Basic knowledge of PHPCR-ODM.
 
 The CMS will have two types of content:


### PR DESCRIPTION
some cleanup for the docs

* update links to new locations
* remove some obsolete footnotes (is there a rst tool to automatically spot unused footnotes?)
* renamed Symfony2 to Symfony in all the doc

another question (for a separate cleanup): how long do we keep versionadded information? can we drop 1.x added info, and symfony < 2.8 notes?