### PR TITLE
drop old versionadded notes to clean up the doc

### DIFF
--- a/bundles/_partials/ivory_ckeditor.rst.inc
+++ b/bundles/_partials/ivory_ckeditor.rst.inc
@@ -1,9 +1,6 @@
 ``ivory_ckeditor``
 ~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 1.3
-    IvoryCKEditorBundle integration was introduced in version 1.3.
-
 This configures integration of the IvoryCKEditorBundle_, so an admin can edit
 content using CKeditor.
 

--- a/bundles/content/exposing_content_via_rest.rst
+++ b/bundles/content/exposing_content_via_rest.rst
@@ -139,11 +139,6 @@ However it might be necessary to add additional mapping to more tightly
 control what gets exposed. See the `documentation of the JMS serializer`_
 for details.
 
-.. versionadded:: 1.1
-    The `default response format changed between 1.0 and 1.1 of the ContentBundle`_.
-    In 1.0 the response is wrapped inside an array/tag. This is no longer the
-    case in 1.1
-
 .. _`FOSRestBundle`: https://github.com/FriendsOfSymfony/FOSRestBundle
 .. _`JMSSerializerBundle`: https://github.com/schmittjoh/JMSSerializerBundle
 .. _`FOSRestBundle view layer`: https://symfony.com/doc/current/bundles/FOSRestBundle/2-the-view-layer.html

--- a/bundles/core/templating.rst
+++ b/bundles/core/templating.rst
@@ -39,9 +39,6 @@ Basic repository operations
 * **cmf_path|getPath($document)**: Get the path of the provided document.
 * **cmf_parent_path|getParentPath($document)**: Get the path of the parent of the provided document.
 
-.. versionadded:: 1.3.1
-    The cmf_find_translation twig function has been added in version 1.3.1 of the CMF CoreBundle.
-
 Walking the PHPCR tree
 ......................
 

--- a/bundles/create/introduction.rst
+++ b/bundles/create/introduction.rst
@@ -129,12 +129,6 @@ overwrite them) are:
         }
     }
 
-.. versionadded:: 1.2
-    The Symfony CMF bundles updated to PSR-4 autoloading with Symfony CMF
-    1.2. Before, the target directories were located in the
-    ``vendor/symfony-cmf/create-bundle/Symfony/Cmf/Bundle/CreateBundle/Resources/public/vendor``
-    directory.
-
 Add this bundle (and its dependencies, if they are not already added) to your
 application's kernel::
 
@@ -546,10 +540,6 @@ Mapping Requests to Domain Objects
 One last piece is the mapping between CreatePHP data and the application
 domain objects. Data needs to be stored back into the database.
 
-.. versionadded:: 1.3
-    The chain mapper and ORM configuration was introduced in CreateBundle
-    1.3. Prior, only the PHPCR-ODM mapper was available.
-
 Adding Custom Mappers to the Chain
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -592,9 +582,6 @@ your own mapper in place of the chain mapper.
 
 Workflows
 ---------
-
-.. versionadded:: 1.1
-    Support for workflows was introduced in CreateBundle 1.1.
 
 CreateJS uses a REST api for creating, loading and changing content. To delete content
 the HTTP method DELETE is used. Since deleting might be a more complex operation

--- a/bundles/media/adapters/elfinder.rst
+++ b/bundles/media/adapters/elfinder.rst
@@ -84,11 +84,6 @@ Installation
                 ),
            ));
 
-.. versionadded:: 2.0
-    The above configuration is intended for the FMElfinderBundle version 2.0
-    and above. Version 1 used a different format without the possibility to
-    configure more than one editor.
-
 .. note::
 
     The driver service depends on your storage layer. For now, the MediaBundle

--- a/bundles/media/form_types.rst
+++ b/bundles/media/form_types.rst
@@ -153,9 +153,6 @@ To delete an image, you need to delete the document containing the image.
 cmf_media_file
 ~~~~~~~~~~~~~~
 
-.. versionadded: 1.3
-    The ``cmf_media_file`` form type was introduced in MediaBundle 1.3.
-
 The ``cmf_media_file`` form maps to an object that implements the
 ``Symfony\Cmf\Bundle\MediaBundle\FileInterface``.
 It renders as a file upload button with a link for downloading the existing

--- a/bundles/media/introduction.rst
+++ b/bundles/media/introduction.rst
@@ -229,9 +229,6 @@ The media bundle contains a Twig extension, it contains the following functions:
            }
         }) }}" title="Download">Download</a>
 
-.. versionadded:: 1.3
-    Option `imagine_runtime_config` was introduced in MediaBundle 1.3
-
 SonataMediaBundle Integration
 -----------------------------
 

--- a/bundles/menu/configuration.rst
+++ b/bundles/menu/configuration.rst
@@ -102,10 +102,6 @@ know which subtree to show when selecting content for menu nodes.
 If the :doc:`CoreBundle <../core/introduction>` is registered, this will default to
 the value of ``%cmf_core.persistence.phpcr.basepath%/content``
 
-.. versionadded:: 1.1
-
-    The pre-fetch functionality was added in MenuBundle 1.1.
-
 ``prefetch``
 """"""""""""
 
@@ -145,10 +141,6 @@ This setting is used by the admin class.
 
 content_url_generator
 ~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 1.2
-    This option was introduced in version 1.2.0. Prior to 1.2, this option is
-    not available and the default service ``router`` is hardcoded.
 
 **type**: ``string`` **default**: ``router``
 
@@ -239,9 +231,6 @@ Enable the :ref:`bundles_menu_voters_uri_prefix_voter`.
 
 ``publish_workflow``
 ~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 1.1
-    The ``publish_workflow`` option was introduced in CmfMenuBundle 1.1.
 
 This configures if the menu content voter for the publish workflow should be
 disabled, by default it is enabled if the :doc:`CoreBundle <../core/introduction>`

--- a/bundles/menu/menu_documents.rst
+++ b/bundles/menu/menu_documents.rst
@@ -117,9 +117,6 @@ The standard menu node implements ``PublishTimePeriodInterface`` and
 ``PublishableInterface``. Please refer to the
 :doc:`publish workflow documentation <../core/publish_workflow>`.
 
-.. versionadded:: 1.1
-    The ``MenuContentVoter`` was added in CmfMenuBundle 1.1.
-
 The ``MenuContentVoter`` decides that a menu node is not published if the
 content it is pointing to is not published.
 

--- a/bundles/menu/menu_factory.rst
+++ b/bundles/menu/menu_factory.rst
@@ -15,11 +15,6 @@ extensions for additional functionality.
 URL Generation
 --------------
 
-.. versionadded:: 2.0
-    Adding content support to the ``knp_menu.factory`` service was introduced
-    in CmfMenuBundle 2.0. Prior to 2.0, you had to use the
-    ``ContentAwareFactory`` class and ``cmf_menu.factory`` service.
-
 Most menu items will need a URL. By default, KnpMenu allows generating this URL
 by specifying a URI or a Symfony route name.
 
@@ -37,9 +32,6 @@ content URL generator can work with. When using the :ref:`dynamic router
     When you don't use the dynamic router, you can create a custom url
     generator by implementing ``UrlGeneratorInterface`` and configure it using
     the ``content_url_generator`` option in ``config.yml``.
-
-    .. versionadded:: 1.2
-        The ``content_url_generator`` option was introduced in CmfMenuBundle 1.2.
 
 How to handle Items without an URL
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/bundles/phpcr_odm/configuration.rst
+++ b/bundles/phpcr_odm/configuration.rst
@@ -128,18 +128,6 @@ parameters. This section explains the general parameters that are
 available with all Jackalope backends. You can also
 :ref:`activate logging and profiling <reference-configuration-phpcr-odm-logging>`.
 
-.. versionadded:: 1.1
-    Since DoctrinePhpcrBundle 1.1, backend configuration flags are configured
-    in the ``parameters`` section. They are passed as-is to Jackalope. See the
-    ``RepositoryFactory`` for some more documentation on the meaning of those
-    parameters.
-
-    For backwards compatibility reason, the options on ``backend`` for
-    ``check_login_on_server``, ``disable_stream_wrapper`` and
-    ``disable_transactions`` still work, but it is recommended to move them
-    into the parameters section with the ``jackalope.`` part in front of them.
-    Note that only Jackalope Doctrine Dbal supports transactions.
-
 ``jackalope.factory``
 .....................
 
@@ -154,11 +142,6 @@ Use a custom factory class for Jackalope objects.
 
 If set to ``false``, skip initial check whether repository exists. You will
 only notice connectivity problems on the first attempt to use the repository.
-
-.. versionadded:: 1.3.1
-   In version 1.2 and 1.3.0 of the DoctrinePhpcrBundle, the default value depends
-   on ``%kernel.debug%``. We recommend setting the value to false to avoid
-   bootstrapping issues.
 
 ``jackalope.disable_stream_wrapper``
 ....................................
@@ -185,9 +168,6 @@ See `last modified listener cookbook entry`_.
 If you are using one of the Jackalope Jackrabbit backend, you can set
 the curl options which are described in the php-documentation
 `curl-setopt`_.
-
-.. versionadded:: 1.3
-    Since jackalope-jackrabbit 1.3, curl-options can be configured.
 
 PHPCR Session with Jackalope Jackrabbit
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/bundles/phpcr_odm/fixtures_initializers.rst
+++ b/bundles/phpcr_odm/fixtures_initializers.rst
@@ -35,11 +35,6 @@ paths it will create if they do not exist and an optional string defining
 namespaces and primary / mixin node types in the CND language that should be
 registered with the repository.
 
-.. versionadded:: 1.1
-    Since version 1.1, the ``GenericInitializer`` expects a name parameter
-    as first argument. With 1.0 there is no way to specify a custom name
-    for the generic Initializer.
-
 A service to use the generic Initializer looks like this:
 
 .. configuration-block::
@@ -94,10 +89,9 @@ You can execute your Initializers using the following command:
 
     $ php bin/console doctrine:phpcr:repository:init
 
-.. versionadded:: 1.1
-    Since DoctrinePHPCRBundle 1.1 the load data fixtures command will
-    automatically execute the Initializers after purging the database,
-    before executing the fixtures.
+.. note::
+    The load data fixtures command automatically executes the Initializers
+    after purging the database, before executing the fixtures.
 
 The generic Initializer only creates PHPCR nodes. If you want to create
 specific documents, you need your own Initializer. The interesting method
@@ -148,12 +142,6 @@ from which you can retrieve the PHPCR session but also the document manager::
             return 'Site Initializer';
         }
     }
-
-.. versionadded:: 1.1
-    Since version 1.1, the ``init`` method is passed the ``ManagerRegistry`` rather
-    than the PHPCR ``SessionInterface`` to allow the creation of documents in
-    Initializers. With 1.0, you would need to manually set the ``phpcr:class``
-    property to the right value.
 
 Define a service for your Initializer as follows:
 

--- a/bundles/routing/configuration.rst
+++ b/bundles/routing/configuration.rst
@@ -388,10 +388,6 @@ manager_name
 ``route_basepaths``
 *******************
 
-.. versionadded:: 1.3
-    The ``route_basepaths`` setting was introduced in version 1.3. Prior to
-    1.3, you could only configure one basepath using ``route_basepath``.
-
 **type**: ``string`` | ``array`` **default**: ``/cms/routes``
 
 A set of paths where routes are located in the PHPCR tree.
@@ -403,9 +399,6 @@ default to ``%cmf_core.persistence.phpcr.basepath%/routes``.
 **********************
 
 **type**: ``boolean`` **default**: ``true``
-
-.. versionadded:: 1.3
-    This configuration option was introduced in RoutingBundle 1.3.
 
 The bundle comes with an initializer that creates the necessary nodes for all
 ``route_basepaths`` roots to exist automatically when initializing the
@@ -437,9 +430,6 @@ The name of the Doctrine Manager to use.
 **type**: ``string`` **default**: ``'Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm\Route'``
 
 The route class to use in your application.
-
-.. versionadded:: 2.0
-    The ``route_class`` parameter has been added in version 2.0.
 
 ``uri_filter_regexp``
 ~~~~~~~~~~~~~~~~~~~~~

--- a/bundles/routing/dynamic_customize.rst
+++ b/bundles/routing/dynamic_customize.rst
@@ -214,9 +214,6 @@ information on creating custom services.
 Using a Custom URL Generator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 1.4
-    The configuration option to specify a custom URL generator was introduced in CmfRoutingBundle 1.4.
-
 The dynamic router can also generate URLs from route objects. If you need to
 customize this behavior beyond what the
 :ref:`route generate event <components-routing-events>` allows, you can

--- a/bundles/routing_auto/definitions.rst
+++ b/bundles/routing_auto/definitions.rst
@@ -4,11 +4,6 @@
 Multiple Auto Routes
 ====================
 
-.. versionadded: 2.0
-
-    The capability to add multiple routes for a managed object has been
-    introduced in RoutingAutoBundle 2.0.
-
 In the introduction you were shown an example using a single auto route schema
 definition. It is possible to have multiple auto-route definitions for each of your
 managed objects, and therefore multiple routes.

--- a/bundles/routing_auto/token_providers.rst
+++ b/bundles/routing_auto/token_providers.rst
@@ -1,6 +1,6 @@
 .. index::
     single: Path Providers; RoutingAutoBundle
-    
+
 Token Providers
 ===============
 
@@ -128,9 +128,6 @@ feature.
 
 ``container``
 -------------
-
-.. versionadded:: 1.1
-    The container provider was introduced in RoutingAutoBundle 1.1
 
 The ``container`` provider allows you to use parameters which have
 been defined in the Symfony DI container.

--- a/bundles/seo/alternate_locale.rst
+++ b/bundles/seo/alternate_locale.rst
@@ -1,9 +1,6 @@
 Alternate Locale Handling
 =========================
 
-.. versionadded:: 1.1
-    Support for handling alternate locales was added in SeoBundle version 1.1.0.
-
 Alternate locales are a way of telling search engines how to find translations
 of the current page. The SeoBundle provides a way to manage alternate locales
 and render them together with the other SEO information.
@@ -104,6 +101,5 @@ use your custom alternate locale provider instead of the default one. Set the
             ],
         ]);
 
-.. versionadded:: 1.2
-    When :doc:`Sitemaps <sitemap>` are enabled, alternate locales are also
-    added to the Sitemap.
+When :doc:`Sitemaps <sitemap>` are enabled, alternate locales are also
+added to the Sitemap.

--- a/bundles/seo/configuration.rst
+++ b/bundles/seo/configuration.rst
@@ -98,9 +98,6 @@ Can be one of ``canonical`` or ``redirect``.
 ``content_listener``
 ~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 1.2
-    The ``content_listener`` configuration key was introduced in SeoBundle 1.2.
-
 ``enabled``
 """""""""""
 
@@ -119,15 +116,8 @@ RoutingBundle is present, this defaults to ``DynamicRouter::CONTENT_KEY``
 (which evaluates to ``contentDocument``), otherwise you must define this
 manually or disable the content listener.
 
-.. versionadded:: 1.2
-    In versions of the SeoBundle prior to 1.2, the ``content_key`` was
-    configured directly in the ``cmf_seo`` root.
-
 ``sitemap``
 ~~~~~~~~~~~
-
-.. versionadded:: 1.2
-    Support for sitemaps was introduced in version 1.2 of the SeoBundle.
 
 For details on the meaning of the sitemap configuration, see the
 :doc:`sitemap section <sitemap>`.
@@ -259,9 +249,6 @@ Limit which of the loaders should be used for this sitemap.
 ``seo_metadata``
 ****************
 
-.. versionadded:: 1.2
-    The ``seo_metadata`` setting was introduced in version 1.2.
-
 **type**: ``string`` **default**: ``Symfony\Cmf\Bundle\SeoBundle\Model\SeoMetadata``
 
 Configures the class to use when creating new ``SeoMetadata`` objects using the
@@ -274,9 +261,6 @@ this defaults to ``Symfony\Cmf\Bundle\SeoBundle\Doctrine\Phpcr\SeoMetadata``.
 
 error
 ~~~~~
-
-.. versionadded:: 1.2
-    The ``error`` settings were introduced in SeoBundle 1.2.
 
 .. seealso::
 
@@ -364,9 +348,6 @@ routes, use:
 
 ``alternate_locale``
 ~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 1.1
-    Support for alternate locales was added in version 1.1 of the SeoBundle.
 
 .. configuration-block::
 

--- a/bundles/seo/error_pages.rst
+++ b/bundles/seo/error_pages.rst
@@ -1,9 +1,6 @@
 Displaying Relevant Pages in Error Pages
 ========================================
 
-.. versionadded:: 1.2
-    The ``SuggestionProviderController`` was introduced in SeoBundle 1.2.
-
 You don't want to lose visitors when no content is found. Instead of showing a
 generic 404 error page, the SEO bundle provides the means to show potentially
 relevant links to help the user find something useful.

--- a/bundles/seo/introduction.rst
+++ b/bundles/seo/introduction.rst
@@ -141,9 +141,6 @@ critical for your application performance.
 The Twig Extension
 ~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 1.2
-    The twig extension was added in SeoBundle 1.2.
-
 This bundle provides a twig function ``cmf_seo_update_metadata``
 which lets you populate the seo page from an object.
 For details on using the twig extension, read :doc:`twig`.

--- a/bundles/seo/sitemap.rst
+++ b/bundles/seo/sitemap.rst
@@ -1,9 +1,6 @@
 Building Sitemaps
 =================
 
-.. versionadded:: 1.2
-    Sitemap support was introduced in SeoBundle 1.2.
-
 This bundle helps loading documents that should go in a sitemap, extracting
 the information from them and rendering them to a sitemap information.
 

--- a/bundles/seo/twig.rst
+++ b/bundles/seo/twig.rst
@@ -1,9 +1,6 @@
 Setting Seo Metadata from Twig
 ==============================
 
-.. versionadded:: 1.2
-    The twig extension was added in SeoBundle 1.2.
-
 This bundle provides a twig function ``cmf_seo_update_metadata``
 which lets you populate the SEO data from an object.
 For details on how populating the SEO data works, read :doc:`introduction`.

--- a/bundles/simple_cms/configuration.rst
+++ b/bundles/simple_cms/configuration.rst
@@ -181,18 +181,4 @@ Configure integration with CmfMenuBundle.
             'use_menu' => 'auto',
         ));
 
-``routing``
-~~~~~~~~~~~
-
-.. versionadded:: 1.1
-    Since SimpleCmsBundle 1.1, this configuration is done directly on the
-    :ref:`RoutingBundle <reference-config-routing-dynamic>`.
-
-``multilang``
-~~~~~~~~~~~~~
-
-.. versionadded:: 1.1
-    Since SimpleCmsBundle 1.1, this configuration is done directly on the
-    :ref:`RoutingBundle <reference-config-routing-locales>`.
-
 .. include:: ../_partials/ivory_ckeditor.rst.inc

--- a/components/routing/dynamic.rst
+++ b/components/routing/dynamic.rst
@@ -48,9 +48,6 @@ a URL:
 * **cmf_routing.pre_dynamic_generate** (Dispatched at the beginning of the
   ``generate`` method)
 
-.. versionadded:: 1.4
-    The route generate event was added in version 1.4 of the routing component.
-
 Pre-match events are of class ``Symfony\Cmf\Component\Routing\Event\RouterMatchEvent``,
 the generate event is of class ``Symfony\Cmf\Component\Routing\Event\RouterGenerateEvent``.
 The generate event also allows you to manipulate the route name, parameters and

--- a/tutorial/make-homepage.rst
+++ b/tutorial/make-homepage.rst
@@ -129,12 +129,6 @@ node::
         }
     }
 
-.. versionadded:: 1.1
-    Since version 1.1, the ``init`` method receives the ``ManagerRegistry``
-    rather than the PHPCR ``SessionInterface``. This allows the creation of
-    documents in initializers. With 1.0, you would need to manually set the
-    ``phpcr:class`` property to the right value.
-
 Now:
 
 1. *Remove* the initializer service that you created in the

--- a/tutorial/the-frontend.rst
+++ b/tutorial/the-frontend.rst
@@ -235,10 +235,6 @@ configuration:
             ->addTag('knp_menu.provider')
         ;
 
-.. versionadded:: 2.0
-    The first argument of the ``PhpcrMenuProvider`` class was changed in CmfMenuBundle 2.0.
-    You had to inject the ``cmf_menu.factory`` service prior to version 2.0.
-
 and enable the Twig rendering functionality of the KnpMenuBundle:
 
 .. configuration-block::


### PR DESCRIPTION
version change notifications for 1.x versions are no longer relevant. there is the 1.x branch of the docs for users of old cmf installations.

as discussed in #837