### PR TITLE
[BUGFIX] Use correct class namespace

### DIFF
--- a/bundles/menu/voters.rst
+++ b/bundles/menu/voters.rst
@@ -265,7 +265,7 @@ A voter will look something like this::
     namespace AppBundle\Voter;
 
     use Knp\Menu\ItemInterface;
-    use Knp\MenuBundle\Matcher\Voter\VoterInterface;
+    use Knp\Menu\Matcher\Voter\VoterInterface;
 
     class MyVoter implements VoterInterface
     {


### PR DESCRIPTION
This fixes an incorrect import from the KnpMenuBundle rather
than the correct KnpMenu project.
The correct intended file is present at [1].

https://github.com/KnpLabs/KnpMenu/blob/master/src/Knp/Menu/Matcher/Voter/VoterInterface.php