### PR TITLE
(DoctrinePHPCRBundle) Document the necessary App document mapping in the configuration section

### DIFF
--- a/cookbook/database/create_new_project_phpcr_odm.rst
+++ b/cookbook/database/create_new_project_phpcr_odm.rst
@@ -105,6 +105,14 @@ content repository.
            odm:
                auto_mapping: true
                auto_generate_proxy_classes: "%kernel.debug%"
+               mappings:
+                   App:
+                       mapping: true
+                       type: annotation
+                       dir: '%kernel.root_dir%/Document'
+                       alias: App
+                       prefix: App\Document\
+                       is_bundle: false
 
     .. code-block:: xml
 
@@ -119,6 +127,15 @@ content repository.
 
                 <odm auto-mapping="true"
                     auto-generate-proxy-classes="%kernel.debug%"
+                />
+
+                <mapping name="App"
+                    mapping="true"
+                    type="annotation"
+                    dir="%kernel.root_dir%/Document"
+                    alias="App"
+                    prefix="App\Document\"
+                    is_bundle="false"
                 />
             </config>
         </container>
@@ -135,6 +152,16 @@ content repository.
             'odm' => array(
                 'auto_mapping' => true,
                 'auto_generate_proxy_classes' => '%kernel.debug%',
+                'mappings' => [
+                    'App' => [
+                        'mapping' => true,
+                        'type' => 'annotation',
+                        'dir' => '%kernel.root_dir%/Document',
+                        'alias' => 'App',
+                        'prefix' => 'App\Document\',
+                        'is-bundle' => false,
+                    ],
+                ],
             ),
         ));
 


### PR DESCRIPTION
As part of a fix of a hard-coded mapping, default application level mapping is no longer offered out of the box (https://github.com/doctrine/DoctrinePHPCRBundle/pull/330).

In a minimal setup, mappings section is now necessary in most cases to offer document mappings on application level.