### PR TITLE
Comma inside table breaking docs build

### DIFF
--- a/bundles/core/templating.rst
+++ b/bundles/core/templating.rst
@@ -62,7 +62,7 @@ Walking the PHPCR tree
 | ``cmf_next``               | ``getNext``              | ``$current``,            | Get the next sibling document from ``$current`` (a document or a path)    |
 |                            |                          | ``$anchor = null``,      | in PHPCR order. ``$anchor`` and ``$depth`` have the same semantics as in  |
 |                            |                          | ``$depth = null``,       | ``getPrev``.                                                              |
-|                            |                          | ``$ignoreRole = false``  ,                                                                           |
+|                            |                          | ``$ignoreRole = false``  |                                                                           |
 |                            |                          | ``$class = null``        |                                                                           |
 +----------------------------+--------------------------+--------------------------+---------------------------------------------------------------------------+
 | ``cmf_next_linkable``      | ``getNextLinkable``      | ``$current``,            | Get the next document that can be linked to, according to the             |


### PR DESCRIPTION
Just something I noticed while playing with the docs building process...

Thanks!