### PR TITLE
Remove Porn URL from documentation #859

### DIFF
--- a/quick_tour/the_big_picture.rst
+++ b/quick_tour/the_big_picture.rst
@@ -227,4 +227,4 @@ section: ":doc:`the_model`".
 .. _KnpMenuBundle: http://knpbundles.com/KnpLabs/KnpMenuBundle
 .. _Composer: https://getcomposer.org/
 .. _`Create.js`: http://createjs.org/
-.. _CreatePHP: http://demo.createphp.org/
+.. _CreatePHP: https://github.com/openpsa/createphp


### PR DESCRIPTION
Hi there,

The website http://demo.createphp.org/ no longer exists and redirects to a porn website.
https://symfony.com/doc/current/cmf/quick_tour/the_big_picture.html#live-editing

Should we redirect to the github project ? (https://github.com/openpsa/createphp)

Best regards.